### PR TITLE
Remove header ids from DXP Cloud docs

### DIFF
--- a/docs/dxp-cloud/latest/en/build-and-deploy/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/continuous-integration.md
@@ -1,7 +1,3 @@
----
-header-id: continuous-integration
----
-
 # Continuous Integration
 
 DXP Cloud uses [Jenkins](https://jenkins.io/) to power its continuous integration infrastructure service by default. When you send a pull request or push a commit to one of your pre-configured GitHub branches, an automatic and configurable build will be triggered.

--- a/docs/dxp-cloud/latest/en/build-and-deploy/intro.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/intro.md
@@ -1,7 +1,3 @@
----
-header-id: development-life-cycle
----
-
 # Development Life Cycle
 
 DXP Cloud helps administrators manage applications throughout their development life cycle. Administrators and developers can use DXP Cloud to build an application and manage the builds in their environment. Once a build succeeds, administrators can deploy it to any environment. DXP Cloud also uses [Jenkins](https://jenkins.io/) continuous integration by default and persistent storage volumes for their services.

--- a/docs/dxp-cloud/latest/en/getting-started/configuring-your-github-repository.md
+++ b/docs/dxp-cloud/latest/en/getting-started/configuring-your-github-repository.md
@@ -1,7 +1,3 @@
----
-header-id: configuring-your-github-repository
----
-
 # Configuring Your Github Repository
 
 Upon receiving a DXP Cloud onboarding email, you're provisioned a GitHub repository hosted in the `dxpcloud` organization. This repository should be used as a template for a team's separate private DXP Cloud development repository and is typically removed after 10 business days. Users are expected to:

--- a/docs/dxp-cloud/latest/en/getting-started/understanding-dxp-cloud-environments.md
+++ b/docs/dxp-cloud/latest/en/getting-started/understanding-dxp-cloud-environments.md
@@ -1,7 +1,3 @@
----
-header-id: environments
----
-
 # Understanding DXP Cloud Environments
 
 A DXP Cloud project can have multiple environments, each for a different 

--- a/docs/dxp-cloud/latest/en/getting-started/welcome-to-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/getting-started/welcome-to-dxp-cloud.md
@@ -1,7 +1,3 @@
----
-header-id: welcome-to-dxp-cloud
----
-
 # Welcome to DXP Cloud
 
 Liferay DXP Cloud is a secure and reliable enterprise cloud platform that 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/connecting-a-vpn-to-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/connecting-a-vpn-to-dxp-cloud.md
@@ -1,7 +1,3 @@
----
-header-id: vpn-connection
----
-
 # Connecting a VPN to DXP Cloud
 
 You can use DXP Cloud's VPN feature to connect your DXP Cloud services to 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
@@ -1,7 +1,3 @@
----
-header-id: custom-domains
----
-
 # Custom Domains
 
 To add a custom domain to a DXP Cloud service, you must first register that 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/intro.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/intro.md
@@ -1,7 +1,3 @@
----
-header-id: networking
----
-
 # Networking
 
 Your DXP Cloud services can communicate securely with external services and 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
@@ -1,7 +1,3 @@
----
-header-id: load-balancer
----
-
 # Load Balancer
 
 The Ingress Load Balancer gives internet access to your environment's services 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/private-network.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/private-network.md
@@ -1,7 +1,3 @@
----
-header-id: private-network
----
-
 # Private Network
 
 Every environment has its own private network. This lets services from the 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/web-application-firewall.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/web-application-firewall.md
@@ -1,7 +1,3 @@
----
-header-id: web-application-firewall
----
-
 # Web Application Firewall
 
 DXP Cloud provides built-in Web Application Firewall (WAF) capabilities,

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -1,7 +1,3 @@
----
-header-id: application-metrics
----
-
 # Application Metrics
 
 With DXP Cloud's built-in monitoring, administrators can track the following information about all services:

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -1,7 +1,3 @@
----
-header-id: auto-scaling
----
-
 # Auto-scaling
 
 Liferay DXP Cloud's auto-scaling feature automatically creates and destroys 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/real-time-alerts.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/real-time-alerts.md
@@ -1,7 +1,3 @@
----
-header-id: real-time-alerts
----
-
 # Real-Time Alerts
 
 Liferay DXP Cloud can alert system administrators of unexpected behaviors in a 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/team-collaboration-and-access-control.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/team-collaboration-and-access-control.md
@@ -1,7 +1,3 @@
----
-header-id: team-collaboration-access-control
----
-
 # Team Collaboration & Access Control
 
 Administrators can manage team members and their roles in a DXP Cloud project. 

--- a/docs/dxp-cloud/latest/en/platform-services/backup-and-restore.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-and-restore.md
@@ -1,7 +1,3 @@
----
-header-id: backup-and-restore
----
-
 # Backup and Restore
 
 It's important for production applications' data to be safe. DXP Cloud can 

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service.md
@@ -1,7 +1,3 @@
----
-header-id: backup-service
----
-
 # Backup Service
 
 The backup service creates regular backups of your Liferay DXP database and 

--- a/docs/dxp-cloud/latest/en/platform-services/database-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/database-service.md
@@ -1,7 +1,3 @@
----
-header-id: database-service-mysql
----
-
 # Database Service (MySQL)
 
 The database service (MySQL) is a distributed relational database service that 

--- a/docs/dxp-cloud/latest/en/platform-services/search-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/search-service.md
@@ -1,7 +1,3 @@
----
-header-id: search-service-elasticsearch
----
-
 # Search Service (Elasticsearch)
 
 The Elasticsearch service is the text search engine for your Liferay DXP 

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -1,7 +1,3 @@
----
-header-id: web-server-service-nginx
----
-
 # Web Server Service (Nginx)
 
 The Nginx web server functions as a gateway from the open internet to your DXP 

--- a/docs/dxp-cloud/latest/en/reference/command-line-tool.md
+++ b/docs/dxp-cloud/latest/en/reference/command-line-tool.md
@@ -1,7 +1,3 @@
----
-header-id: command-line-tool
----
-
 # Command-line Tool
 
 Liferay DXP's command-line interface (CLI) is a tool that helps you use and 

--- a/docs/dxp-cloud/latest/en/reference/configuration-via-lcp-json.md
+++ b/docs/dxp-cloud/latest/en/reference/configuration-via-lcp-json.md
@@ -1,7 +1,3 @@
----
-header-id: configuration-via-lcp-json
----
-
 # Configuration via LCP.json
 
 Each service in your DXP Cloud environments has an `LCP.json` file that you can 

--- a/docs/dxp-cloud/latest/en/reference/defining-environment-variables.md
+++ b/docs/dxp-cloud/latest/en/reference/defining-environment-variables.md
@@ -1,7 +1,3 @@
----
-header-id: defining-environment-variables
----
-
 # Defining Environment Variables
 
 Environment variables are a set of dynamic placeholders that can affect the way a service behaves within an environment.

--- a/docs/dxp-cloud/latest/en/reference/intro.md
+++ b/docs/dxp-cloud/latest/en/reference/intro.md
@@ -1,7 +1,3 @@
----
-header-id: reference
----
-
 # Reference
 
 This is the reference documentation for DXP Cloud. The following topics are 

--- a/docs/dxp-cloud/latest/en/reference/support-access.md
+++ b/docs/dxp-cloud/latest/en/reference/support-access.md
@@ -1,7 +1,3 @@
----
-header-id: support-access
----
-
 # Support Access
 
 Support Access is an optional setting that expedites troubleshooting by giving 

--- a/docs/dxp-cloud/latest/en/troubleshooting/log-management.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/log-management.md
@@ -1,7 +1,3 @@
----
-header-id: log-management
----
-
 # Log Management
 
 Logs are crucial for debugging. On DXP Cloud, you can access your environment's 

--- a/docs/dxp-cloud/latest/en/troubleshooting/shell-access.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/shell-access.md
@@ -1,7 +1,3 @@
----
-header-id: shell-access
----
-
 # Shell Access
 
 The command-line tools in DXP Cloud contribute to the developer's workflow by 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -1,7 +1,3 @@
----
-header-id: using-the-liferay-dxp-service
----
-
 # Introduction to the Liferay DXP Service
 
 The Liferay DXP service is the heartbeat of any project. It runs the application's Liferay DXP instance and interacts with other services like the web server, Elasticsearch, and MySQL database.

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -1,7 +1,3 @@
----
-header-id: migrating-from-an-on-premises-dxp-installation
----
-
 # Migrating from an On-Premises DXP Installation
 
 This article will walk you through the essential steps for migrating your 


### PR DESCRIPTION
Removing the header-ids from all DXP Cloud docs. The titles are now the first line of each doc, same as with the other products.