### PR TITLE
Clean up sphinx parsing errors

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/web-application-firewall.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/web-application-firewall.md
@@ -51,7 +51,7 @@ that DXP Cloud provides.
 Users can leverage the `allow` and `deny` directives inside the `stream` context
 or `server` block in the `nginx.conf` file:
 
-```properties
+```
 stream {
     ...
     server {

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -21,14 +21,16 @@ Before using the Dynatrace advanced monitoring features, the following requireme
 * The Dynatrace secret `token` and `tenant` values have been generated.
 * Dynatrace environment variables have been added to the `LCP.json` file in the DXP Service's production environment. For example:
 
-```properties
-"environments": {
-  "prd": {
-    "env": {
-      "LCP_PROJECT_MONITOR_DYNATRACE_TENANT": "tot02934",
-      "LCP_PROJECT_MONITOR_DYNATRACE_TOKEN": "dDKSowkdID8dKDkCkepW"
-    }
-  }
+```json
+{
+	"environments": {
+	  "prd": {
+	    "env": {
+	      "LCP_PROJECT_MONITOR_DYNATRACE_TENANT": "tot02934",
+	      "LCP_PROJECT_MONITOR_DYNATRACE_TOKEN": "dDKSowkdID8dKDkCkepW"
+	    }
+	  }
+	}
 }
 ```
 

--- a/docs/dxp-cloud/latest/en/troubleshooting/self-healing.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/self-healing.md
@@ -30,14 +30,16 @@ The liveness probe uses a URL Request (path/port) to validate that a service is 
 Each service's `LCP.json` file contains the following:
 
 ```json
-"livenessProbe": {
-  "httpGet": {
-    "path": "/status",
-    "port": 3000
-  },
-  "initialDelaySeconds": 40,
-  "periodSeconds": 5,
-  "successThreshold": 5
+{
+  "livenessProbe": {
+    "httpGet": {
+      "path": "/status",
+      "port": 3000
+    },
+    "initialDelaySeconds": 40,
+    "periodSeconds": 5,
+    "successThreshold": 5
+  }
 }
 ```
 
@@ -48,12 +50,14 @@ The readiness probe uses an executable command. If the command returns with the 
 Each service's `LCP.json` file contains the following:
 
 ```json
-"readinessProbe": {
-  "exec": {
-    "command": ["cat", "/tmp/healthy"]
-  },
-  "initialDelaySeconds": 40,
-  "periodSeconds": 5,
+{
+  "readinessProbe": {
+    "exec": {
+      "command": ["cat", "/tmp/healthy"]
+    },
+    "initialDelaySeconds": 40,
+    "periodSeconds": 5
+  }
 }
 ```
 


### PR DESCRIPTION
Changing the code blocks in these files to try to cut down on the noise from all the parsing errors from building with Sphinx.

There are a few more files with errors from similar issues (notably the braces missing from outside the key-value pairs), but I am more reluctant to fix those ones because they are all just one or two values by themselves and it feels like it may be more confusing putting them by themselves in blocks like that.

Let me know if you have any thoughts or concerns pertaining to these changes. Thanks.