### PR TITLE
Fixing commerce links user guide side

### DIFF
--- a/docs/commerce/2.x/en/README.md
+++ b/docs/commerce/2.x/en/README.md
@@ -50,8 +50,8 @@ Payments for orders may be completed with several different [payment methods](./
 
 ![Payment Methods page](./introduction-to-liferay-commerce/images/06.png)
 
-Orders may be fulfilled using several different [shipping methods](../sales/shipping-method-reference.md):
-sellers can [impose a flat rate](../sales/using-the-flat-rate-shipping-method.md), apply [shipping method restrictions](../sales/applying-shipping-method-restrictions.md), or integrate with the [carrier rates like FedEx](../sales/using-fedex-as-a-carrier-method.md).
+Orders may be fulfilled using several different [shipping methods](./user-guide/sales/shipping-method-reference.md):
+sellers can [impose a flat rate](./user-guide/sales/using-the-flat-rate-shipping-method.md), apply [shipping method restrictions](./user-guide/sales/applying-shipping-method-restrictions.md), or integrate with the [carrier rates like FedEx](./user-guide/sales/using-fedex-as-a-carrier-method.md).
 
 ## ML Powered Recommendations and Alerts
 

--- a/docs/commerce/2.x/en/developer-guide/README.md
+++ b/docs/commerce/2.x/en/developer-guide/README.md
@@ -15,18 +15,18 @@ Welcome to the Liferay Commerce Developer Guide.
 
 ### Content
 
-* [Implementing a Sample File Download to Product Details (TODO)](./tutorial/implementing-a-sample-file-download-to-product-details.md)
+* Implementing a Sample File Download to Product Details (TODO)
 * [Implementing a Custom Product Content Renderer](./tutorial/implementing-a-custom-product-content-renderer.md)
 
 ### Managing Inventory
 
-* [Using a Custom Inventory Engine (TODO)](./tutorial/using-a-custom-inventory-engine.md)
+* Using a Custom Inventory Engine (TODO)
 * [Implementing a Custom Low Stock Activity](./tutorial/implementing-a-custom-low-stock-activity.md)
-* [Customizing Warehouse Sourcing Logic for Order Shipments (TODO)](./tutorial/customizing-warehouse-sourcing-logic-for-order-shipments.md)
+* Customizing Warehouse Sourcing Logic for Order Shipments (TODO)
 
 ### Marketing
 
-* [Adding a New Notification Template Type (TODO)](./tutorial/adding-a-new-notification-template-type.md)
+* Adding a New Notification Template Type (TODO)
 * [Adding a New Product Data Source for the Product Publisher Widget](./tutorial/adding-a-new-product-data-source-for-the-product-publisher-widget.md)
 
 ### Promotions
@@ -37,7 +37,7 @@ Welcome to the Liferay Commerce Developer Guide.
 
 * [Implementing a Custom Order Validator](./tutorial/implementing-a-custom-order-validator.md)
 * [Implementing a Custom Checkout Step](./tutorial/implementing-a-custom-checkout-step.md)
-* [Implementing a New Payment Engine (TODO)](./tutorial/implementing-a-new-payment-engine.md)
+* Implementing a New Payment Engine (TODO)
 * [Implementing a New Tax Engine](./tutorial/implementing-a-new-tax-engine.md)
 * [Implementing a New Shipping Engine](./tutorial/implementing-a-new-shipping-engine.md)
 * [Implementing an Exchange Rate Provider](./tutorial/implementing-an-exchange-rate-provider.md)
@@ -45,7 +45,7 @@ Welcome to the Liferay Commerce Developer Guide.
 
 ### Store Administration
 
-* [Adding Regions Programmatically (TODO)](./tutorial/adding-regions-programmatically.md)
+* Adding Regions Programmatically (TODO)
 
 ## Leveraging Liferay Commerce APIs
 

--- a/docs/commerce/2.x/en/developer-guide/tutorial/implementing-an-exchange-rate-provider.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorial/implementing-an-exchange-rate-provider.md
@@ -138,5 +138,5 @@ Congratulations! You now know the basics for implementing the `ExchangeRateProvi
 
 ## Additional Information
 
-* [Currencies](../../user-guide/getting-started/currencies.md)
+* [Adding a New Currency](../../user-guide/getting-started/adding-a-new-currency.md)
 * [Managing Exchange Rates](../../user-guide/getting-started/managing-exchange-rates.md)

--- a/docs/commerce/2.x/en/installation-and-upgrades/quick-start-guide/quick-start-guide.md
+++ b/docs/commerce/2.x/en/installation-and-upgrades/quick-start-guide/quick-start-guide.md
@@ -26,4 +26,4 @@ Follow these steps to download the latest release of Liferay Commerce and get st
 
 Doing more than just checking things out? Learn more about [Installation and Upgrades](../../installation-and-upgrades/README.md).
 
-Want to get a store up and running in minutes? Learn about [Accelerators](../getting-started/accelerators.md).
+Want to get a store up and running in minutes? Learn about [Accelerators](../../user-guide/getting-started/accelerators.md).

--- a/docs/commerce/2.x/en/user-guide/README.md
+++ b/docs/commerce/2.x/en/user-guide/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-* [Introduction to Liferay Commerce](./getting-started/introduction-to-liferay-commerce.md)
+* [Introduction to Liferay Commerce](../README.md)
 * What's New in Liferay Commerce 2.0.5
 
 ### Basic Configuration
@@ -67,10 +67,10 @@
 
 ### Managing Inventory
 
-* [Introduction to Managing Inventory](../catalog/introduction-to-managing-inventory.md)
+* [Introduction to Managing Inventory](./catalog/introduction-to-managing-inventory.md)
 * [Adding a New Warehouse](./catalog/adding-a-new-warehouse.md)
 * [Setting Inventory by Warehouse](./catalog/setting-inventory-by-warehouse.md)
-* [Low Inventory Activity](../catalog/low-stock-activity.md)
+* [Low Inventory Activity](./catalog/low-stock-activity.md)
 * [Availability Estimates](./catalog/availability-estimates.md)
 * [Product Inventory Configuration Reference](./catalog/product-inventory-configuration-reference.md)
 * [Managing Product Publication](./catalog/managing-product-publication.md)
@@ -158,10 +158,10 @@
 
 * [Introduction to Accounts](./customers/introduction-to-accounts.md)
 * [Creating a New Account](./customers/creating-a-new-account.md)
-* [Inviting Users to an Account](../inviting-users-to-an-account.md)
-* [Adding Addresses to an Account](../adding-addresses-to-an-account.md)
+* [Inviting Users to an Account](./customers/inviting-users-to-an-account.md)
+* [Adding Addresses to an Account](./customers/adding-addresses-to-an-account.md)
 * [Account Roles](./customers/account-roles.md)
-* [Assigning Account Roles](../assigning-account-roles.md)
+* [Assigning Account Roles](./customers/assigning-account-roles.md)
 * [Creating a New Account Group](./customers/creating-a-new-account-group.md)
 * Organizations and Accounts
 

--- a/docs/commerce/2.x/en/user-guide/catalog/README.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/README.md
@@ -28,10 +28,10 @@
 
 ## Managing Inventory
 
-* [Introduction to Managing Inventory](../introduction-to-managing-inventory.md)
+* [Introduction to Managing Inventory](./introduction-to-managing-inventory.md)
 * [Adding a New Warehouse](./adding-a-new-warehouse.md)
 * [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md)
-* [Low Inventory Activity](../low-stock-activity.md)
+* [Low Inventory Activity](./low-stock-activity.md)
 * [Availability Estimates](./availability-estimates.md)
 * [Product Inventory Configuration Reference](./product-inventory-configuration-reference.md)
 * [Managing Product Publication](./managing-product-publication.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/adding-a-new-warehouse.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/adding-a-new-warehouse.md
@@ -24,4 +24,4 @@ The new warehouse is now active and available as an option in the _Shipment_ tab
 
 Before you can enter the address for a warehouse, you may need to enter and activate the applicable country and region (state or province) in the _Countries_ tab at _Control Panel_ → _Commerce_ → _Settings_.
 
-For more detail see [Country Options](../getting-started/country-options.md).
+For more detail see [Adding Regions](../getting-started/adding-regions.md) or [Deactivating a Country for Billing or Shipping](../getting-started/deactivating-a-country-for-billing-or-shipping.md).

--- a/docs/commerce/2.x/en/user-guide/catalog/adding-tiered-pricing.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/adding-tiered-pricing.md
@@ -26,4 +26,4 @@ A pricing tier ($90) has been created for orders that reach the minimum quantity
 **Note**: Price Tier Entries can also be reached by directly viewing Product SKUs.
 
 * [Creating a Price List](../catalog/creating-a-price-list.md)
-* [Adding Products to a Price List](../adding-products-to-a-price-list/README.md)
+* [Adding Products to a Price List](./adding-products-to-a-price-list.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/availability-estimates.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/availability-estimates.md
@@ -24,5 +24,5 @@ When configuring the low stock threshold, this Availability Estimate option is d
 
 ## Additional Information
 
-* [Introduction to Managing Inventory](../introduction-to-managing-inventory/README.md)
-* [Product Inventory Configuration Reference](../product-inventory-configuration-reference/README.md)
+* [Introduction to Managing Inventory](./introduction-to-managing-inventory.md)
+* [Product Inventory Configuration Reference](./product-inventory-configuration-reference.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/creating-a-grouped-product.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/creating-a-grouped-product.md
@@ -83,11 +83,11 @@ To set product prices and quantities:
         ![Grouped Product Pricing](./creating-a-grouped-product/images/06.png)
 
 1. Click _Save_. (If Promo Price and Cost fields are left as 0.00, no discounts or promotions are applied at this point.)
-1. Click _Price List_ to apply this product to any existing [Price Lists](../../../managing-price/price-lists/adding-products-to-a-price-list/README.md).
+1. Click _Price List_ to apply this product to any existing [Price Lists](./adding-products-to-a-price-list.md).
 
->To learn more about pricing see: [Introduction to Product Pricing Methods](../../../managing-price/introduction-to-product-pricing-methods/README.md)
+>To learn more about pricing see: [Introduction to Product Pricing Methods](./introduction-to-product-pricing-methods.md)
 
-To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](../../../managing-inventory/setting-inventory-by-warehouse/README.md).
+To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md).
 
 ### Configure Product Specifications
 
@@ -105,7 +105,7 @@ Store administrators can also add attachments that are associated with a particu
 
 ### Associate with Related Products
 
-[Product Relations](../../product-information/product-relations/README.md) can be used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
+[Product Relations](./related-products-up-sells-and-cross-sells.md) can be used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
 
 ### Selling Grouped Products
 

--- a/docs/commerce/2.x/en/user-guide/catalog/creating-a-price-list.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/creating-a-price-list.md
@@ -33,5 +33,5 @@ The price list (_VIP Customers_ in this example) has been created and applied to
 
 * [Creating a New Account Group](../customers/creating-a-new-account-group.md)
 * [Creating a New Account](../customers/creating-a-new-account.md)
-* [Adding Products to a Price List](../adding-products-to-a-price-list/README.md)
+* [Adding Products to a Price List](./adding-products-to-a-price-list.md)
 * [Adding Tiered Pricing](../catalog/adding-products-to-a-price-list.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/creating-a-simple-product.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/creating-a-simple-product.md
@@ -52,11 +52,11 @@ To set product prices and quantities:
     * **Promo Price**: 0.00
     * **Cost**: 0.00
 1. Click _Save_. (If Promo Price and Cost fields are left as 00, no discounts or promotions are applied at this point.)
-1. Click _Price List_ to apply this product to any existing [price lists](../../../managing-price/price-lists/adding-products-to-a-price-list/README.md).
+1. Click _Price List_ to apply this product to any existing [price lists](./adding-products-to-a-price-list.md).
 
-> To learn more about pricing, see: [Introduction to Product Pricing Methods](../../../managing-price/introduction-to-product-pricing-methods/README.md)
+> To learn more about pricing, see: [Introduction to Product Pricing Methods](./introduction-to-product-pricing-methods.md)
 
-To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](../../../managing-inventory/setting-inventory-by-warehouse/README.md).
+To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md).
 
 ### Configure Product Specifications
 
@@ -74,11 +74,11 @@ Store administrators can also add attachments that are associated with a particu
 
 ### Associate with Related Products
 
-[Product Relations](../../product-information/product-relations/README.md) are used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
+[Product Relations](./related-products-up-sells-and-cross-sells.md) are used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
 
 ## Additional Information
 
 * [Introduction to Product Types](../catalog/introduction-to-product-types.md)
 * [Creating a Grouped Product](../catalog/creating-a-grouped-product.md)
 * [Creating a Virtual Product](../catalog/creating-a-virtual-product.md)
-* [Setting Inventory by Warehouse](../../../managing-inventory/setting-inventory-by-warehouse/README.md)
+* [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/creating-a-virtual-product.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/creating-a-virtual-product.md
@@ -67,11 +67,11 @@ To set product prices and quantities:
     * **Promo Price**: 0.00
     * **Cost**: 0.00
 1. Click _Save_. (If Promo Price and Cost fields are left as 0.00, no discounts or promotions are applied at this point.)
-1. Click _Price List_ to apply this product to any existing [Price Lists](../../../managing-price/price-lists/adding-products-to-a-price-list/README.md).
+1. Click _Price List_ to apply this product to any existing [Price Lists](./adding-products-to-a-price-list.md).
 
->To learn more about pricing see: [Introduction to Product Pricing Methods](../../../managing-price/introduction-to-product-pricing-methods/README.md)
+>To learn more about pricing see: [Introduction to Product Pricing Methods](./introduction-to-product-pricing-methods.md)
 
-To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](../../../managing-inventory/setting-inventory-by-warehouse/README.md).
+To learn how to configure inventory for your product, see: [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md).
 
 ### Add Product Specifications
 
@@ -89,7 +89,7 @@ Store administrators can also add attachments that are associated with a particu
 
 ### Associate with Related Products
 
-[Product Relations](../../product-information/product-relations/README.md) can be used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
+[Product Relations](./related-products-up-sells-and-cross-sells.md) can be used to connect products. Once connected, a product displays the links to other products. Every related product must be assigned to a Product Relation Type.
 
 ## Additional Information
 

--- a/docs/commerce/2.x/en/user-guide/catalog/introduction-to-managing-inventory.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/introduction-to-managing-inventory.md
@@ -8,7 +8,7 @@ There are several key features used in managing inventory: Warehouses, Availabil
 
 Warehouses represent the physical locations where product inventory is managed and sourced for order fulfillment.
 
-See the [Warehouse Reference Guide](../warehouse-reference-guide/README.md) and the [Adding a New Warehouse](../catalog/adding-a-new-warehouse.md) article for more information about how to manage warehouses.
+See the [Warehouse Reference Guide](./warehouse-reference-guide.md) and the [Adding a New Warehouse](../catalog/adding-a-new-warehouse.md) article for more information about how to manage warehouses.
 
 Warehouses must be associated for at least one channel. See the [Introduction to Channels](../catalog/introduction-to-channels.md) article on how channels work.
 
@@ -20,15 +20,15 @@ See the [Availability Estimates](../catalog/availability-estimates.md) for more 
 
 ## Low Stock Activity
 
-Low Stock Activities can be configured to perform automated actions when available product inventory reaches a specified threshold. See the [Low Stock Activity](../low-stock-activity/README.md) to learn how to configure what behavior is executed when inventory reaches a minimum threshold.
+Low Stock Activities can be configured to perform automated actions when available product inventory reaches a specified threshold. See the [Low Stock Activity](./low-stock-activity.md) to learn how to configure what behavior is executed when inventory reaches a minimum threshold.
 
 Developers interested in creating their own custom low stock activity can refer to [Implementing a Custom Low Stock Activity](../../developer-guide/tutorial/implementing-a-custom-low-stock-activity.md).
 
 ## Setting Inventory by Warehouse
 
-In Liferay Commerce, inventory management is done per product SKU. To learn more, read the [Setting Inventory by Warehouse](../setting-inventory-by-warehouse/README.md) article.
+In Liferay Commerce, inventory management is done per product SKU. To learn more, read the [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md) article.
 
 ## Additional Information
 
 * Shipping - Creating a New Shipment (TODO)
-* [Product Inventory Configuration Reference](../product-inventory-configuration-reference/README.md)
+* [Product Inventory Configuration Reference](./product-inventory-configuration-reference.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/introduction-to-product-pricing-methods.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/introduction-to-product-pricing-methods.md
@@ -8,7 +8,7 @@ The pricing hierarchy determines which price applies for any given combination o
 
 The hierarchy consists of these levels:
 
-**Base Price**: This is the starting price of the product which is [set](../base-price/setting-a-products-base-price/README.md) in the product SKU sub-tab.
+**Base Price**: This is the starting price of the product which is [set](./setting-a-products-base-price.md) in the product SKU sub-tab.
 
 **Price List**: This price applies to specific products for buyers in selected [Accounts](../customers/creating-a-new-account.md) and [Account Groups](../customers/creating-a-new-account-group.md). Prices in the price list can be _higher_ or _lower_ than the base price. If a price list applies to a transaction, it supersedes the base price.
 
@@ -39,8 +39,8 @@ The pricing hierarchy can be visualized in the following diagram:
 
 ## Additional Information
 
-* [Setting a Product's Base Price](../base-price/setting-a-products-base-price/README.md)
+* [Setting a Product's Base Price](./setting-a-products-base-price.md)
 * [Creating a Price List](../catalog/creating-a-price-list.md)
-* [Adding Products to a Price List](../price-lists/adding-products-to-a-price-list/README.md)
+* [Adding Products to a Price List](./adding-products-to-a-price-list.md)
 * [Adding Tiered Pricing](../catalog/adding-products-to-a-price-list.md)
 * [Adding Discounts by Product](../marketing/adding-discounts-by-product.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/low-stock-activity.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/low-stock-activity.md
@@ -28,5 +28,5 @@ The Low Stock Activity for this product has been configured. In the future, shou
 
 ## Additional Information
 
-* [Product Inventory Configuration Reference](../product-inventory-configuration-reference/README.md)
+* [Product Inventory Configuration Reference](./product-inventory-configuration-reference.md)
 * [Implementing a Custom Low Stock Activity](../../developer-guide/tutorial/implementing-a-custom-low-stock-activity.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/product-inventory-configuration-reference.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/product-inventory-configuration-reference.md
@@ -25,4 +25,4 @@ To manage the inventory for each product, navigate to a Product's _Configuration
 ## Additional Information
 
 * [Implementing a Custom Low Stock Activity](../../developer-guide/tutorial/implementing-a-custom-low-stock-activity.md)
-* [Low Stock Activity](../low-stock-activity/README.md)
+* [Low Stock Activity](./low-stock-activity.md)

--- a/docs/commerce/2.x/en/user-guide/catalog/warehouse-reference-guide.md
+++ b/docs/commerce/2.x/en/user-guide/catalog/warehouse-reference-guide.md
@@ -40,4 +40,4 @@ If there are more than one warehouse, repeat these steps to add the others.
 
 * Introduction to Shipments (TODO)
 * [Adding a New Warehouse](../catalog/adding-a-new-warehouse.md)
-* [Setting Inventory by Warehouse](../setting-inventory-by-warehouse/README.md)
+* [Setting Inventory by Warehouse](./setting-inventory-by-warehouse.md)

--- a/docs/commerce/2.x/en/user-guide/getting-started/liferay-commerce-configuration-overview.md
+++ b/docs/commerce/2.x/en/user-guide/getting-started/liferay-commerce-configuration-overview.md
@@ -23,12 +23,12 @@ The Commerce Global Settings menu contains the following tabs:
 ![Commerce Global Settings Tab](./liferay-commerce-configuration-overview/images/02.png)
 
 * [Availability Estimates](../catalog/availability-estimates.md)
-* [Countries](../getting-started/country-options.md)
-* [Currencies](../getting-started/currencies.md)
+* [Adding a New Currency](../getting-started/adding-a-new-currency.md)
 * Default Images
 * [Measurement Units](../sales/measurement-units.md)
 * Health Check
-* [Warehouses](../../catalog/managing-inventory/warehouse-reference-guide/README.md)
+* [Regions](../getting-started/adding-regions.md)
+* [Warehouses](../catalog/warehouse-reference-guide.md)
 
 ## Commerce Site Settings
 
@@ -47,6 +47,6 @@ The following site settings are found here:
 * Order Fields
 * [Payment Methods](../getting-started/payments.md)
 * Product Display Pages
-* [Shipping Methods](../sales/shipping.md)
+* [Shipping Methods](../sales/shipping-method-reference.md)
 * [Site Types](../getting-started/sites-and-site-types.md)
 * Taxes

--- a/docs/commerce/2.x/en/user-guide/getting-started/store-setup-overview.md
+++ b/docs/commerce/2.x/en/user-guide/getting-started/store-setup-overview.md
@@ -23,7 +23,7 @@ Global configurations for Liferay Commerce include setting the store timezone, a
 
 * [Setting Locale Options](../getting-started/locale-options.md)
 * [Adding Regions](../getting-started/adding-regions.md)
-* [Setting up Warehouses](../../catalog/managing-inventory/warehouse-reference-guide/README.md)
+* [Setting up Warehouses](../catalog/warehouse-reference-guide.md)
 * [Creating Channels](../catalog/introduction-to-channels.md)
 
 ### Create a Store Site
@@ -66,7 +66,7 @@ Liferay Commerce has several options to calculate shipping rates. Commerce Enter
 
 ## Creating the Catalog
 
-After setting up the store, begin [creating a catalog](../../catalog/creating-a-catalog/README.md).
+After setting up the store, begin [creating a new catalog](../catalog/creating-a-new-catalog.md).
 
 ### Adding Products to a Catalog
 
@@ -76,14 +76,14 @@ When adding a product, there are three product types: **Simple**, **Grouped**, a
 
 The Liferay Commerce Catalog supports storing and managing a wide variety of product information. The following articles cover some of the available options:
 
-* [Product Options](../../catalog/creating-and-managing-products/customizing-your-product-with-product-options)
+* [Product Options](../catalog/customizing-your-product-with-product-options.md)
 * [Product Specifications](../catalog/specifications.md)
 * [Product Images](../catalog/product-images.md)
 * Product Attachments
 * [Product Relations](../catalog/related-products-up-sells-and-cross-sells.md)
 * [Product Categorization](../catalog/organizing-your-catalog-with-product-categories.md)
 * [Availability Estimates](../catalog/availability-estimates.md)
-* [Low Stock Activity](../../catalog/managing-inventory/low-stock-activity/README.md)
+* [Low Stock Activity](../catalog/low-stock-activity.md)
 * Applicable Tax Category
 * Associated Channels
 * Associated Account Groups
@@ -93,13 +93,13 @@ The Liferay Commerce Catalog supports storing and managing a wide variety of pro
 
 There are several ways to price products and these methods are related to one another in a pricing hierarchy: base price, price list, tiered price, promo price and discount. Pricing is managed per SKU.
 
-* [Pricing](../../catalog/managing-price/introduction-to-product-pricing-methods/README.md)
+* [Pricing](../catalog/introduction-to-product-pricing-methods.md)
 * [Price Lists](../catalog/creating-a-price-list.md)
 * [Discounts](../marketing/adding-discounts-by-product.md)
 
 #### Managing Inventory
 
-* [Introduction to Managing Inventory](../../catalog/managing-inventory/introduction-to-managing-inventory/README.md)
+* [Introduction to Managing Inventory](../catalog/introduction-to-managing-inventory.md)
 * Subscriptions (if applicable)
 
 ## Creating the Storefront

--- a/docs/commerce/2.x/en/user-guide/getting-started/using-the-minium-accelerator-to-jump-start-your-b2b-store.md
+++ b/docs/commerce/2.x/en/user-guide/getting-started/using-the-minium-accelerator-to-jump-start-your-b2b-store.md
@@ -1,8 +1,8 @@
 # Using the Minium Accelerator to Jump-Start Your B2B Store
 
-Minium is a Liferay Commerce [Accelerator](../README.md) that quickly and easily sets up a business-to-business (B2B) store designed to meet the needs of a manufacturer, showcasing a modern B2B digital commerce experience. It is designed with features that make the experience as smooth as possible by having elements that are both functional and elegant.
+Minium is a Liferay Commerce [Accelerator](./accelerators.md) that quickly and easily sets up a business-to-business (B2B) store designed to meet the needs of a manufacturer, showcasing a modern B2B digital commerce experience. It is designed with features that make the experience as smooth as possible by having elements that are both functional and elegant.
 
-The accelerator accomplishes this by providing the base hierarchy of site pages and design, sample data, and configurations for a site in a single action. Minium also highlights Liferay Commerce's B2B Account Management functionality, enabling streamlined account management and self-service through the use of [Account Roles](../customers/account-roles.md), [Account Groups](../customers/creating-a-new-account-group.md), and [Order Workflows](../../../sales/order-management/order-workflows/).
+The accelerator accomplishes this by providing the base hierarchy of site pages and design, sample data, and configurations for a site in a single action. Minium also highlights Liferay Commerce's B2B Account Management functionality, enabling streamlined account management and self-service through the use of [Account Roles](../customers/account-roles.md), [Account Groups](../customers/creating-a-new-account-group.md), and [Order Workflows](../sales/order-workflows.md).
 
 This article serves as a walk-through for the main features of the Minium Accelerator.
 
@@ -58,7 +58,7 @@ Minium applies a number of other site configurations that are not set out-of-the
 | [Site Type](../getting-started/sites-and-site-types.md) | B2B |
 | [Shipping Method Options](../sales/using-the-flat-rate-shipping-method.md) | Standard Delivery, Expedited Delivery |
 | Channels | Minium Portal |
-| [Countries](../getting-started/country-options.md) | France, China, United States, and 245 more |
+| Countries | France, China, United States, and 245 more |
 | [Currencies](../getting-started/adding-a-new-currency.md) | USD, AUD, GBP, and 7 more |
 | Default Image | &#10003; |
 | [Measurement Units](../sales/measurement-units.md) - Dimensions | inches, millimeters, feet, meters |

--- a/docs/commerce/2.x/en/user-guide/marketing/adding-discounts-by-product.md
+++ b/docs/commerce/2.x/en/user-guide/marketing/adding-discounts-by-product.md
@@ -13,7 +13,7 @@ To create a discount by product:
 1. Enter a name: _Christmas Sale_.
 1. Select a discount type from the _Target_ drop down. Select _Apply to Product_.
 1. Check the box for which channel this discount applies to.
-1. Select which [Account Groups](../../../customers/account-management/creating-a-new-account-group//README.md) this discount applies to. In this example, _US East Coast_.
+1. Select which [Account Groups](../customers/creating-a-new-account-group.md) this discount applies to. In this example, _US East Coast_.
 1. Switch the _Use Percentage_ toggle to _Yes_.
 1. Enter the _Maximum Discount Amount_: 20%.
 1. Enter the _Level_: 1.00

--- a/docs/commerce/2.x/en/user-guide/marketing/adding-discounts-to-the-subtotal.md
+++ b/docs/commerce/2.x/en/user-guide/marketing/adding-discounts-to-the-subtotal.md
@@ -1,6 +1,6 @@
 # Adding Discounts to the Subtotal
 
-A discount applies a modifier to a product’s base price. It can be an absolute number or a percentage, and can be applied to a limited number of products or to the entire catalog. It can be available to all buyers, a defined Account Group, or to a more narrowly defined group of customers that meet certain qualifications. Unlike a price list, a discount always _reduces_ the base price. For more information on Pricing see [Introduction to Product Pricing Methods](../../../catalog/managing-price/introduction-to-product-pricing-methods/README.md).
+A discount applies a modifier to a product’s base price. It can be an absolute number or a percentage, and can be applied to a limited number of products or to the entire catalog. It can be available to all buyers, a defined Account Group, or to a more narrowly defined group of customers that meet certain qualifications. Unlike a price list, a discount always _reduces_ the base price. For more information on Pricing see [Introduction to Product Pricing Methods](../catalog/introduction-to-product-pricing-methods.md).
 
 There are five different types of discounts: Categories, Products, Shipment, Subtotal, and Total. This article is a walk through on how to add discounts to the Subtotal.
 
@@ -13,7 +13,7 @@ To create this type of discount:
 1. Enter a name: _Spring Sale_.
 1. Select a discount type from the _Target_ drop down. Select _Apply to Subtotal_.
 1. Check the box for which channel this discount applies to.
-1. Select which [Account Groups](../../../customers/account-management/creating-a-new-account-group//README.md) this discount applies to. In this example, _US East Coast_.
+1. Select which [Account Groups](../customers/creating-a-new-account-group.md) this discount applies to. In this example, _US East Coast_.
 1. Switch the _Use Percentage_ toggle to _Yes_.
 1. Enter the _Maximum Discount Amount_: 20%.
 1. Enter the _Level_: 1.00

--- a/docs/commerce/2.x/en/user-guide/marketing/automating-store-emails-by-using-notification-templates.md
+++ b/docs/commerce/2.x/en/user-guide/marketing/automating-store-emails-by-using-notification-templates.md
@@ -39,7 +39,3 @@ The new Notification Template has been saved and your store will send an automat
 **Note 3**: To change the interval for when Liferay Commerce checks for unsent notifications, navigate to the _Control Menu_ → _Configuration_ → _System Settings_. Click _Orders_ then the _Commerce Notification Queue_. The default values are listed in minutes. Change the values for the Check Interval and the Delete Interval if necessary.
 
 ![Changing Intervals](./automating-store-emails-by-using-notification-templates/images/02.png)
-
-## Additional Information
-
-* [Adding a New Notification Type](../../developer-guide/tutorial/adding-a-new-notification-template-type.md)

--- a/docs/commerce/2.x/en/user-guide/sales/applying-shipping-method-restrictions.md
+++ b/docs/commerce/2.x/en/user-guide/sales/applying-shipping-method-restrictions.md
@@ -19,5 +19,5 @@ Your store is now restricted from shipping to those countries. Repeat these step
 ## Additional Information
 
 * [Using the Flat Rate Shipping Method](../sales/using-the-flat-rate-shipping-method.md)
-* [Variable Rate]()
+* [Variable Rate](./using-the-variable-rate-shipping-method.md)
 * [Using FedEx as a Carrier Method](../sales/using-fedex-as-a-carrier-method.md)

--- a/docs/commerce/2.x/en/user-guide/sales/authorize.net.md
+++ b/docs/commerce/2.x/en/user-guide/sales/authorize.net.md
@@ -26,6 +26,6 @@ Once finished, Authorize.Net is now enabled.
 
 ## Additional Information
 
-* [Currencies](../getting-started/currencies.md)
+* [Adding a New Currency](../getting-started/adding-a-new-currency.md)
 * [Mercanet](../sales/mercanet.md)
 * [PayPal](../sales/mercanet.md)

--- a/docs/commerce/2.x/en/user-guide/sales/creating-a-shipment.md
+++ b/docs/commerce/2.x/en/user-guide/sales/creating-a-shipment.md
@@ -49,6 +49,6 @@ The order manager can update the status of the shipment as needed, until the ord
 ## Additional Information
 
 * [Adding a New Warehouse](../catalog/adding-a-new-warehouse.md)
-* [Setting Inventory by Warehouse](../../../../catalog/managing-inventory/setting-inventory-by-warehouse/README.md)
+* [Setting Inventory by Warehouse](../catalog/setting-inventory-by-warehouse.md)
 * [Order Life Cycle](../sales/order-life-cycle.md)
 * [Order Information](../sales/order-information.md)

--- a/docs/commerce/2.x/en/user-guide/sales/enabling-or-disabling-order-workflows.md
+++ b/docs/commerce/2.x/en/user-guide/sales/enabling-or-disabling-order-workflows.md
@@ -36,7 +36,7 @@ To disable an order workflow, simply navigate to the _Order Workflows_ tab, sele
 **Note**: Out-of-the-box, _Single Approver (Version 1)_ is the available order workflow. [Custom workflows](https://help.liferay.com/hc/en-us/articles/360018174111-Introduction-to-Workflow) can be created and may then be selected in the _Order Workflows_ tab.
 
 * [Order Workflows](../README.md)
-* [Approving or Rejecting Orders](../approving-or-rejecting-orders/README.md)
+* [Approving or Rejecting Orders](./approving-or-rejecting-orders-in-order-workflows.md)
 * [Order Life Cycle](../sales/order-life-cycle.md)
 * [Orders Menu](../sales/orders-menu.md)
 * Order Management Statuses

--- a/docs/commerce/2.x/en/user-guide/sales/mercanet.md
+++ b/docs/commerce/2.x/en/user-guide/sales/mercanet.md
@@ -48,6 +48,6 @@ Mercanet is now enabled for your store.
 
 ## Additional Information
 
-* [Currencies](../getting-started/currencies.md)
+* [Adding a New Currency](../getting-started/adding-a-new-currency.md)
 * [Authorize.Net](../sales/authorize.net.md)
 * [PayPal](../sales/mercanet.md)

--- a/docs/commerce/2.x/en/user-guide/sales/money-orders.md
+++ b/docs/commerce/2.x/en/user-guide/sales/money-orders.md
@@ -27,7 +27,3 @@ Your store may now accept Money Orders as a form of payment.
 1. Click _Save_.
 
 Your translated note will be displayed in that language whenever visitors from that locale visit that page.
-
-**Note 2**:
-
-For more information about where the money order note is published, read [Displaying Your Money Order Policy]().

--- a/docs/commerce/2.x/en/user-guide/sales/paypal.md
+++ b/docs/commerce/2.x/en/user-guide/sales/paypal.md
@@ -23,7 +23,7 @@ PayPal is now enabled for your store.
 
 Here is more information about adding other payment methods:
 
+* [Adding a New Currency](../getting-started/adding-a-new-currency/)
 * [Authorize.net](../sales/authorize.net.md)
 * [Mercanet](../sales/mercanet.md)
-* [Currencies](../../../../getting-started/currencies/)
 * [Reattempt failed recurring payments with Subscribe buttons](https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/reattempt-failed-payment/)

--- a/docs/commerce/2.x/en/user-guide/sales/using-the-flat-rate-shipping-method.md
+++ b/docs/commerce/2.x/en/user-guide/sales/using-the-flat-rate-shipping-method.md
@@ -25,7 +25,7 @@ The new Shipping Option has been added and is available during the checkout proc
 
 ## Additional Information
 
-* [Using the Variable Rate Shipping Method]()
+* [Using the Variable Rate Shipping Method](./using-the-variable-rate-shipping-method.md)
 * [Using FedEx as a Carrier Method](../sales/using-fedex-as-a-carrier-method.md)
 * [Applying Shipping Method Restrictions](../sales/applying-shipping-method-restrictions.md)
 * [Creating New Shipping Methods](https://help.liferay.com/hc/en-us/articles/360020751831)

--- a/site/docs/_static/main.css
+++ b/site/docs/_static/main.css
@@ -8110,7 +8110,14 @@ th {
     list-style: none;
     padding: 0; }
   .documentations .doc-nav .back-link {
-    margin-left: 1rem; }
+    align-items: center;
+    display: flex;
+    padding-left: 1rem;
+    width: 100%; }
+    .documentations .doc-nav .back-link svg {
+      height: 1.5rem;
+      padding-right: 0.75rem;
+      width: 1.5rem; }
   .documentations .doc-nav .toctree-l1.active a {
     color: #0B5FFF; }
   .documentations .doc-nav .toctree-l1.current > a {

--- a/site/docs/_static/main.css
+++ b/site/docs/_static/main.css
@@ -8031,6 +8031,7 @@ th {
   margin: 0;
   padding: 0; }
   .breadcrumb li {
+    color: #6c757d;
     font-size: 0.875rem;
     font-weight: 600;
     margin-right: 0.5rem;
@@ -8052,7 +8053,7 @@ th {
         top: 50%;
         width: 0.75em; }
     .breadcrumb li a {
-      color: #6c757d; }
+      color: #30313F; }
       .breadcrumb li a:hover {
         text-decoration: none; }
 

--- a/site/docs/_templates/page.html
+++ b/site/docs/_templates/page.html
@@ -18,12 +18,13 @@
                 </div>
 
                 <div class="doc-nav">
-                    <a class="back-link btn btn-monospaced btn-link" href="javascript:;" id="backButton">
+                    <a class="back-link btn btn-monospaced btn-link" href="javascript:;" id="backLink">
                         <svg id="angle-left" viewBox="0 0 512 512">
                             <path class="lexicon-icon-outline"
                                 d="M114.106 254.607c0.22 6.936 2.972 13.811 8.272 19.11l227.222 227.221c11.026 11.058 28.94 11.058 39.999 0 11.058-11.026 11.058-28.94 0-39.999l-206.333-206.333c0 0 206.333-206.333 206.333-206.333 11.058-11.059 11.058-28.973 0-39.999-11.058-11.059-28.973-11.059-39.999 0l-227.221 227.221c-5.3 5.3-8.052 12.174-8.273 19.111z">
                             </path>
                         </svg>
+                        {% trans %}Go Back{% endtrans %}
                     </a>
 
                     {% block sidebar1 %}
@@ -208,14 +209,14 @@
         backURL = breadcrumbAncestor ? breadcrumbAncestor.href : 'https://learn.liferay.com';
     }
 
-    // Set href for back button
+    // Set href for back link
 
     var backURL;
 
-    const backButton = document.getElementById('backButton');
+    const backLink = document.getElementById('backLink');
 
-    if (backButton) {
-        backButton.href = backURL;
+    if (backLink) {
+        backLink.href = backURL;
     }
 </script>
 {% endblock %}

--- a/site/docs/_templates/page.html
+++ b/site/docs/_templates/page.html
@@ -169,16 +169,7 @@
             }
         });
 
-        if (!level2Active) {
-
-            // Redirect to first article under a section if a user clicks on the section heading
-
-            const activeNavL2FirstChildAnchor = activeNavL2List.item(0).children[0];
-
-            if (activeNavL2FirstChildAnchor) {
-                window.location.href = activeNavL2FirstChildAnchor.href;
-            }
-        } else {
+        if (level2Active) {
 
             // Zoom in on the current section
 

--- a/site/docs/_templates/page.html
+++ b/site/docs/_templates/page.html
@@ -186,18 +186,6 @@
             backURL = breadcrumbParents[breadcrumbParents.length - 1].href;
         }
 
-        // Highlight current Product Category
-
-        const breadcrumbCurrentArticle = document.getElementById('breadcrumbCurrentArticle');
-
-        if (breadcrumbCurrentArticle) {
-            nonActiveNavL1.forEach(node => {
-                if (node && node.firstChild.innerText === breadcrumbCurrentArticle.innerText) {
-                    node.classList.add('active');
-                }
-            })
-        }
-
         // Set back URL
 
         backURL = breadcrumbAncestor ? breadcrumbAncestor.href : '';

--- a/site/docs/_templates/page.html
+++ b/site/docs/_templates/page.html
@@ -164,6 +164,11 @@
     let backURL = null;
 
     if (activeNavL1 && backLink) {
+
+        // Zoom in on the current section
+
+        nonActiveNavL1.forEach(node => node.classList.add('d-none'));
+
         const activeNavL2List = activeNavL1.querySelectorAll('li.toctree-l2');
         let level2Active = false;
 
@@ -174,10 +179,6 @@
         });
 
         if (level2Active) {
-
-            // Zoom in on the current section
-
-            nonActiveNavL1.forEach(node => node.classList.add('d-none'));
 
             // Set back URL
 

--- a/site/docs/_templates/page.html
+++ b/site/docs/_templates/page.html
@@ -159,7 +159,11 @@
     const activeNavL1 = document.querySelector('.toctree-l1.current');
     const nonActiveNavL1 = document.querySelectorAll('.toctree-l1:not(.current)');
 
-    if (activeNavL1) {
+    const backLink = document.getElementById('backLink');
+
+    let backURL = null;
+
+    if (activeNavL1 && backLink) {
         const activeNavL2List = activeNavL1.querySelectorAll('li.toctree-l2');
         let level2Active = false;
 
@@ -175,13 +179,12 @@
 
             nonActiveNavL1.forEach(node => node.classList.add('d-none'));
 
-            // Set parent level URL
+            // Set back URL
 
             const breadcrumbParents = document.querySelectorAll('.breadcrumb-parent');
 
             backURL = breadcrumbParents[breadcrumbParents.length - 1].href;
         }
-    } else {
 
         // Highlight current Product Category
 
@@ -195,19 +198,15 @@
             })
         }
 
-        // Set backURL
+        // Set back URL
 
-        backURL = breadcrumbAncestor ? breadcrumbAncestor.href : 'https://learn.liferay.com';
-    }
+        backURL = breadcrumbAncestor ? breadcrumbAncestor.href : '';
 
-    // Set href for back link
-
-    var backURL;
-
-    const backLink = document.getElementById('backLink');
-
-    if (backLink) {
         backLink.href = backURL;
+    } else {
+        if (backLink) {
+            backLink.classList.add('d-none');
+        }
     }
 </script>
 {% endblock %}

--- a/site/homepage/_static/main.css
+++ b/site/homepage/_static/main.css
@@ -8110,7 +8110,14 @@ th {
     list-style: none;
     padding: 0; }
   .documentations .doc-nav .back-link {
-    margin-left: 1rem; }
+    align-items: center;
+    display: flex;
+    padding-left: 1rem;
+    width: 100%; }
+    .documentations .doc-nav .back-link svg {
+      height: 1.5rem;
+      padding-right: 0.75rem;
+      width: 1.5rem; }
   .documentations .doc-nav .toctree-l1.active a {
     color: #0B5FFF; }
   .documentations .doc-nav .toctree-l1.current > a {

--- a/site/homepage/_static/main.css
+++ b/site/homepage/_static/main.css
@@ -8031,6 +8031,7 @@ th {
   margin: 0;
   padding: 0; }
   .breadcrumb li {
+    color: #6c757d;
     font-size: 0.875rem;
     font-weight: 600;
     margin-right: 0.5rem;
@@ -8052,7 +8053,7 @@ th {
         top: 50%;
         width: 0.75em; }
     .breadcrumb li a {
-      color: #6c757d; }
+      color: #30313F; }
       .breadcrumb li a:hover {
         text-decoration: none; }
 

--- a/site/homepage/_static/scss/_breadcrumb.scss
+++ b/site/homepage/_static/scss/_breadcrumb.scss
@@ -6,6 +6,7 @@
 	padding: 0;
 
 	li {
+		color: $breadcrumb-active-color;
 		font-size: $h5-font-size;
 		font-weight: $font-weight-semi-bold;
 		margin-right: 0.5rem;
@@ -35,7 +36,7 @@
 		}
 
 		a {
-			color: $breadcrumb-active-color;
+			color: $default-color;
 
 			&:hover {
 				text-decoration: none;

--- a/site/homepage/_static/scss/_custom_variable.scss
+++ b/site/homepage/_static/scss/_custom_variable.scss
@@ -33,7 +33,6 @@ $h6-font-size: $small-font-size !default; // 12px
 $code-font-size: 14px !default; // set pixel value to prevent nested <pre> and <code> from scaling down font size
 $mobile-font-size: 1.75rem !default; // 28px
 
-$breadcrumb-active-color: null !default;
 $breadcrumb-divider-color: null !default;
 
 // Custom Variables

--- a/site/homepage/_static/scss/_documentations.scss
+++ b/site/homepage/_static/scss/_documentations.scss
@@ -45,7 +45,16 @@
 		}
 
 		.back-link {
-			margin-left: $spacing-md;
+			align-items: center;
+			display: flex;
+			padding-left: $spacing-md;
+			width: 100%;
+
+			svg {
+				height: $spacing-default;
+				padding-right: $spacing-sm;
+				width: $spacing-default;
+			}
 		}
 
 		.toctree-l1 {


### PR DESCRIPTION
This should fix most if not all of the broken links on the user guide for Commerce docs. Note that there were a couple instances where I had to actually remove the link and/or sentence with it (one line in the money orders article talking about displaying where money orders go to, and one or two links to un-implemented dev tutorials, too).

EDIT: there's also fixed links in the base README for the dev guide and base README for Commerce, because I was originally going to do all the Commerce broken links at once. I forgot I still had those in this branch.