### PR TITLE
Top-level link clean-up

### DIFF
--- a/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
@@ -7,7 +7,5 @@ Deploying to DXP Cloud
 ----------------------
 
 -  :doc:`/build-and-deploy/understanding-deployment-types`
--  `Deploying Apps, Themes, and Modules <./using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#themes-portlets-and-osgi-modules>`__
--  `Deploying Customizations from Source <./using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#source-code>`__
 -  :doc:`/build-and-deploy/walking-through-the-deployment-life-cycle`
 -  :doc:'/build-and-deploy/configuring-persistent-file-system-volumes'

--- a/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
@@ -10,3 +10,4 @@ Deploying to DXP Cloud
 -  `Deploying Apps, Themes, and Modules <./using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#themes-portlets-and-osgi-modules>`__
 -  `Deploying Customizations from Source <./using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#source-code>`__
 -  :doc:`/build-and-deploy/walking-through-the-deployment-life-cycle`
+-  :doc:'/build-and-deploy/configuring-persistent-file-system-volumes'

--- a/docs/dxp-cloud/latest/en/build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md
@@ -8,24 +8,15 @@ This article outlines the path developers will take to develop for and deploy to
 
 ## Develop and Configure
 
-Although there are multiple paths for deploying to an environment, all paths 
-begin with adding changes to the GitHub repository 
-[you configured](../getting-started/configuring-your-github-repository.md) 
-with your DXP Cloud project. This repository is used as the basis for any custom 
-additions to a DXP Cloud project, including the Liferay DXP service instance 
-itself. 
+Although there are multiple paths for deploying to an environment, all paths begin with adding changes to the GitHub repository [you configured](../getting-started/configuring-your-github-repository.md) with your DXP Cloud project. This repository is used as the basis for any custom additions to a DXP Cloud project, including the Liferay DXP service instance itself.
 
 The repository provides the following:
 
 * Workspace for building Liferay DXP modules, themes, and extensions. 
-* Shared version control for configuration and customizations of DXP Cloud 
-    services. 
+* Shared version control for configuration and customizations of DXP Cloud services. 
 * Single source of truth for DXP Cloud project deployments. 
 
-With the exception of the `common` folder, changes added to a given service's 
-environment folder (e.g., `dev`, `uat`, `prd`) are only propagated when 
-deploying to the corresponding environment. Changes added to `common` are always 
-deployed regardless of the target deployment environment.
+With the exception of the `common` folder, changes added to a given service's environment folder (e.g., `dev`, `uat`, `prd`) are only propagated when deploying to the corresponding environment. Changes added to `common` are always deployed regardless of the target deployment environment. See [Deployment](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#deployment-customization-patching-and-licensing) for more information.
 
 ### Code Additions
 

--- a/docs/dxp-cloud/latest/en/build_and_deploy.rst
+++ b/docs/dxp-cloud/latest/en/build_and_deploy.rst
@@ -8,9 +8,6 @@ Build and Deploy
    build-and-deploy/understanding-deployment-types.md
    build-and-deploy/walking-through-the-deployment-life-cycle.md
    
-   Deploying Apps, Themes, and Modules </using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.html#themes-portlets-and-osgi-modules>
-   Deploying Customizations From Source </using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.html#source-code>
-   
    build-and-deploy/configuring-persistent-file-system-volumes.md
 
 .. include:: /build-and-deploy/README.rst

--- a/docs/dxp-cloud/latest/en/manage_and_optimize.rst
+++ b/docs/dxp-cloud/latest/en/manage_and_optimize.rst
@@ -4,8 +4,6 @@ Manage and Optimize
 .. toctree::
    :maxdepth: 1
 
-   developer-guide/introduction/introduction-to-the-liferay-commerce-developer-guide.md
-
    manage-and-optimize/auto-scaling.md
    manage-and-optimize/application-metrics.md
    manage-and-optimize/real-time-alerts.md


### PR DESCRIPTION
This fixes some issues in `.rst` files like inter-section nav links (e.g. the `Build & Deploy` README pointing to an article in `Using the Liferay DXP Service` section).