### PR TITLE
create a workflow for building site when a pr or push action is triggered on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [pull_request, push]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Dependencies
+        run: sudo apt-get install python3-venv python3-sphinx
+
+      - name: Build Site
+        run: cd site && ./build_site.sh


### PR DESCRIPTION
You can go into settings to disable merging unless CI passes. This is so that next time someone commits change that will cause site build to fail, it won't be merged. 

The next step is adding that md linting that you wanted. 
The step after that is to use actions to directly deploy to UAT. 