### PR TITLE
Raw directive

### DIFF
--- a/docs/commerce/2.x/en/account-management/landing.html
+++ b/docs/commerce/2.x/en/account-management/landing.html
@@ -1,0 +1,1 @@
+<div>Hello World!</div>

--- a/docs/commerce/2.x/en/account-management/landing.html
+++ b/docs/commerce/2.x/en/account-management/landing.html
@@ -1,1 +1,78 @@
-<div>Hello World!</div>
+<div class="landing-page" id="landingPage">
+	<div class="section-card" v-for="card in cards">
+		<a class="autofit-row autofit-row-center" :href="card.sectionURL">
+			<div class="autofit-col autofit-col-expand">
+				<h4 class="title">{{ card.sectionName }}</h4>
+				<ul class="subsection" v-if="card.subsections">
+					<li v-for="subsection in card.subsections">
+						<a class="subsection-link" :href="subsection.url">
+							{{ subsection.name}}
+						</a>
+					</li>
+				</ul>
+			</div>
+		</a>
+	</div>
+</div>
+
+<script type="module">
+	import Vue from 'https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.esm.browser.min.js'
+
+	const page = new Vue({
+		el: '#landingPage',
+		data: {
+			cards: [
+				{
+					sectionName: 'Introduction to Accounts',
+					sectionURL: 'account-management/introduction-to-accounts.html',
+					subsections: [
+						{
+							name: 'test',
+							url: '/'
+						},
+						{
+							name: 'test1',
+							url: '/'
+						},
+						{
+							name: 'test2',
+							url: '/'
+						}
+					]
+				},
+				{
+					sectionName: 'Creating a New Account',
+					sectionURL: 'account-management/creating-a-new-account.html'
+				},
+				{
+					sectionName: 'Inviting Users to an Account',
+					sectionURL: 'account-management/inviting-users-to-an-account.html'
+				},
+				{
+					sectionName: 'Adding Addresses to an Account',
+					sectionURL: 'account-management/adding-addresses-to-an-account.html'
+				},
+				{
+					sectionName: 'Account Roles',
+					sectionURL: 'account-management/account-roles.html'
+				},
+				{
+					sectionName: 'Commerce Roles Permissions Reference',
+					sectionURL: 'account-management/commerce-roles-permissions-reference.html'
+				},
+				{
+					sectionName: 'Creating a Custom Account Role',
+					sectionURL: 'account-management/creating-a-custom-account-role.html'
+				},
+				{
+					sectionName: 'Assigning User Roles',
+					sectionURL: 'account-management/assigning-account-roles.html'
+				},
+				{
+					sectionName: 'Creating a New Account Group',
+					sectionURL: 'account-management/creating-a-new-account-group.html'
+				}
+			]
+		}
+	})
+</script>

--- a/docs/commerce/2.x/en/account_management.rst
+++ b/docs/commerce/2.x/en/account_management.rst
@@ -14,5 +14,5 @@ Account Management
    account-management/creating-a-new-account-group.md
    account-management/commerce-roles-permissions-reference.md
 
-.. include:: /account-management/README.rst
-   :start-line: 2
+.. raw:: html
+   :file: account-management/landing.html

--- a/site/docs/_static/main.css
+++ b/site/docs/_static/main.css
@@ -8631,6 +8631,33 @@ header {
 .homepage .sub-heading {
   margin: 1.5rem 0 1.5rem; }
 
+.landing-page {
+  display: flex;
+  flex-wrap: wrap; }
+  .landing-page .section-card {
+    border: 1px solid rgba(9, 16, 24, 0.12);
+    border-radius: 0.25rem;
+    box-shadow: 0 6px 15px -6px rgba(9, 16, 29, 0.06);
+    margin-right: 1.5rem;
+    margin-top: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    transition: transform 0.2s ease;
+    width: 45%; }
+    .landing-page .section-card:hover {
+      border-bottom: 3px solid #0B5FFF;
+      box-shadow: 0 6px 11px 0 rgba(9, 16, 29, 0.09);
+      margin-bottom: -3px;
+      text-decoration: none;
+      transform: translateY(-4px); }
+      .landing-page .section-card:hover h4:hover {
+        text-decoration: none; }
+    .landing-page .section-card h4 {
+      font-size: 1.125rem; }
+  .landing-page .subsection {
+    font-size: 0.875rem;
+    list-style: none;
+    padding-inline-start: 0; }
+
 .highlight-link {
   display: none; }
 

--- a/site/homepage/_static/main.css
+++ b/site/homepage/_static/main.css
@@ -8631,6 +8631,33 @@ header {
 .homepage .sub-heading {
   margin: 1.5rem 0 1.5rem; }
 
+.landing-page {
+  display: flex;
+  flex-wrap: wrap; }
+  .landing-page .section-card {
+    border: 1px solid rgba(9, 16, 24, 0.12);
+    border-radius: 0.25rem;
+    box-shadow: 0 6px 15px -6px rgba(9, 16, 29, 0.06);
+    margin-right: 1.5rem;
+    margin-top: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    transition: transform 0.2s ease;
+    width: 45%; }
+    .landing-page .section-card:hover {
+      border-bottom: 3px solid #0B5FFF;
+      box-shadow: 0 6px 11px 0 rgba(9, 16, 29, 0.09);
+      margin-bottom: -3px;
+      text-decoration: none;
+      transform: translateY(-4px); }
+      .landing-page .section-card:hover h4:hover {
+        text-decoration: none; }
+    .landing-page .section-card h4 {
+      font-size: 1.125rem; }
+  .landing-page .subsection {
+    font-size: 0.875rem;
+    list-style: none;
+    padding-inline-start: 0; }
+
 .highlight-link {
   display: none; }
 

--- a/site/homepage/_static/scss/_landing_page.scss
+++ b/site/homepage/_static/scss/_landing_page.scss
@@ -1,0 +1,37 @@
+.landing-page {
+	display: flex;
+	flex-wrap: wrap;
+
+	.section-card {
+		border: 1px solid rgba(9, 16, 24, 0.12);
+		border-radius: $border-radius;
+		box-shadow: 0 6px 15px -6px rgba(9, 16, 29, 0.06);
+		margin-right: $spacing-default;
+		margin-top: $spacing-default;
+		padding: 1.25rem $spacing-default;
+		transition: transform 0.2s ease;
+		width: 45%;
+
+		&:hover {
+			border-bottom: 3px solid $brand-primary;
+			box-shadow: 0 6px 11px 0 rgba(9, 16, 29, 0.09);
+			margin-bottom: -3px;
+			text-decoration: none;
+			transform: translateY(-4px);
+        
+            h4 {
+                text-decoration: none;
+            }
+        }
+
+		h4 {
+			font-size: 1.125rem;
+		}
+	}
+
+	.subsection {
+		font-size: $h5-font-size;
+		list-style: none;
+		padding-inline-start: 0;
+	}
+}

--- a/site/homepage/_static/scss/main.scss
+++ b/site/homepage/_static/scss/main.scss
@@ -57,5 +57,6 @@
 @import "_elements";
 @import "_header";
 @import "_homepage";
+@import "_landing_page";
 @import "_search";
 @import "_style_override";


### PR DESCRIPTION
An example of using the `raw` directive and vue.js (smallest footprint) to create the landing page. There are some kinks with the double bound anchor links inside the vue template, and that there are no icons yet. Since the mockups are not finalized, I figured that's okay for the purpose of evaluating. 

Again, the ideal solution might be to create a custom directive and manage the landing page directly in the `.rst` files using the new directive rather than additional `landing.html` files. 