### PR TITLE
LRDOCS-7655 GMT database not req'd for DXP

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay-dxp-on-premises/configuring-a-database.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay-dxp-on-premises/configuring-a-database.md
@@ -13,8 +13,6 @@ By default for demonstration purposes, Liferay DXP is configured to use an embed
 
 ## Configure the database
 
-1. Use the GMT time zone on your database server.
-
 1. Create a database that uses UTF-8. Here is a MySQL command example:
 
     ```sql


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7655

DXP doesn't require the database itself does not need to be set to GMT timezone.
