### PR TITLE
Add entry in Setting Up Liferay DXP that links to section in Installation & Upgrades

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/installing_and_managing_apps.rst
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/installing_and_managing_apps.rst
@@ -1,0 +1,1 @@
+.. include:: /system-administration/installing-and-managing-apps/README.rst

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting_up_liferay_dxp.rst
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting_up_liferay_dxp.rst
@@ -9,6 +9,7 @@ Setting Up Liferay DXP
    setting-up-liferay-dxp/mail-server-configuration-reference.md
    setting-up-liferay-dxp/configuring_the_document_library_repository.rst
    setting-up-liferay-dxp/configuring_clustering_for_high_availability.rst
+   setting-up-liferay-dxp/installing_and_managing_apps
 
 .. include:: /installation-and-upgrades/setting-up-liferay-dxp/README.rst
    :start-line: 2


### PR DESCRIPTION
Allows the README for `Installing & Managing Apps` to show up in the `Setting Up Liferay DXP` section.

Note that we identified the following drawbacks with this method:
- The side nav is not exactly a smooth experience going from one section to the other
- It further forces us to convert that README to an RST so that the links in the README will continue working whichever directory you're looking at it from (since RSTs use the full path for links as opposed to relative links)