### PR TITLE
DXP cloud custom services

### DIFF
--- a/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/README.rst
@@ -8,5 +8,6 @@ Deploying to DXP Cloud
 
 -  :doc:`/build-and-deploy/understanding-deployment-types`
 -  :doc:`/build-and-deploy/walking-through-the-deployment-life-cycle`
+-  :doc:`/build-and-deploy/using-a-custom-service`
 -  :doc:`/build-and-deploy/configuring-persistent-file-storage-volumes`
 -  :doc:`/build-and-deploy/ignoring-files-and-folders`

--- a/docs/dxp-cloud/latest/en/build-and-deploy/using-a-custom-service.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/using-a-custom-service.md
@@ -1,0 +1,66 @@
+# Using a Custom Service
+
+DXP Cloud allows you to run more than just the standard set of services provided out-of-the-box. You can also create a custom service for anything that would best run within DXP Cloud, but outside of your other services.
+
+```note::
+   You must have sufficient hardware resources to be able to add a custom service. You can allocate additional resources for custom services during the provisioning process.
+```
+
+DXP Cloud uses Docker images as the basis for its services. If you want to run these services locally, then you must [install Docker](https://docs.docker.com/get-docker/) on your local system.
+
+## Steps to Add a Custom Service
+
+1. Create or find your custom service as a Docker image. You can either use a Dockerfile that you add to your project's workspace directly or an image from a public repository like [Docker Hub](https://hub.docker.com/).
+
+1. Add a new directory for your service with an `LCP.json` file. See the `LCP.json` files for other services in your repository for a template on some properties to add.
+
+	```warning::
+      If you trigger a build with a new custom service, but do not have enough resources provisioned for the new service, then it may interfere with the resources allocated to your other services.
+
+      Directly set the memory and CPU allocation for your new service in its LCP.json file to make sure it gets the correct amount of hardware resources.
+	```
+
+1. Specify which environments your service will apply to in your `LCP.json`. This may depend on how many resources you have provisioned for your new service.
+
+	For example, to only apply the build to your `prd` environment, add the following property to your `LCP.json`:
+
+	```json
+	   {
+	      "environments": {
+	         "prd": {
+	            "deploy": true
+	         }
+	      }
+	   }
+	```
+
+	If no such properties are specified, then by default, the service will attempt to build for all environments.
+
+1. Apply your Docker image to the new service. The method to use to add your Docker image depends on whether you are using an image uploaded to a public repository, or a local Dockerfile.
+
+	- **If you are using a Docker image from a public repository:** Add the name of your image to an `image` property within your `LCP.json`:
+
+	```
+	   "image": "@my.custom.service.docker.image@"
+	```
+
+	- **If you are using a local Dockerfile:** Add the Dockerfile into your custom service's directory. When your service is built, the Docker image from the Dockerfile will automatically be picked up as the image for the service.
+
+		```note::
+		   The Dockerfile is automatically used as the image for your service. As a result, any "image" property in your LCP.json will be ignored.
+		```
+
+1. Commit these changes to your branch in version control:
+
+	```
+	   git add my-custom-service/
+	   git commit -m "Add custom service"
+	```
+   
+1. Push your branch up and start a new build in DXP Cloud to deploy. See the information on deployment in the [Overview of DXP Cloud Deployment](./overview-of-the-dxp-cloud-deployment-workflow#deploy) for help with deploying your build.
+
+Once you have triggered a new build in CI with your changes, you can navigate to the _Builds_ screen in the DXP Cloud console to see the build. The services listed under the _Services_ column includes the new service with the others.
+
+## Additional Information
+
+* [Overview of the DXP Cloud Deployment Workflow](./overview-of-the-dxp-cloud-deployment-workflow)

--- a/docs/dxp-cloud/latest/en/build_and_deploy.rst
+++ b/docs/dxp-cloud/latest/en/build_and_deploy.rst
@@ -7,7 +7,8 @@ Build and Deploy
    build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md
    build-and-deploy/understanding-deployment-types.md
    build-and-deploy/walking-through-the-deployment-life-cycle.md
-   
+
+   build-and-deploy/using-a-custom-service.md
    build-and-deploy/configuring-persistent-file-storage-volumes.md
    build-and-deploy/ignoring-files-and-folders.md
 


### PR DESCRIPTION
My draft of the custom services article as requested by [LRDOCS-7657](https://issues.liferay.com/browse/LRDOCS-7657).

This is what I've settled on for now, though here are some points I wasn't entirely satisfied with as I was writing it, so I'm curious if you'd have input:

- I originally wanted to add some example properties to add to the `LCP.json`; at first I copied some of the properties from the `database` service's `LCP.json` to demonstrate some properties that might be good to copy. I took it out, though, because it seemed too awkward just sticking some properties as an "example" when you would still have to change those values to suit your service. Maybe we still want to show an example like that, but if so, I'd probably need a clearer idea of what the "essentials" would be -- and maybe we'd have to impose some sort of "example" properties? But then that might be a bit much, I'm not sure.

- Not sure if the steps are perhaps not direct enough. Because a lot of it is really open-ended (the custom service could be really anything, and we decided beforehand not to impose how to create the service for now as it's a lot to get into), I think not all the steps can be 100% literal and to-the-point (e.g., step one is basically "get your custom service" because I'm not sure if there's really anything else we can say). 
** On a related note, while I showed the commands for adding and committing the new service to the repository, maybe that doesn't make sense in context, especially with some of the other steps being less precise? I really wasn't sure, but I left it in for now.

- Somewhat related to the previous point, I'm not sure if the last step ("Build and deploy" essentially) is too brief. I erred on the side of referencing out to an existing article that discusses deployment because I didn't want to have to include a lot of steps for deploying the changes, when it might be somewhat distracting to the point of the steps. Maybe I'm wrong though, and it still should list those steps (or maybe there's something else better to reference to?).