### PR TITLE
LRDOCS-7514

### DIFF
--- a/docs/dxp-cloud/latest/en/platform-services/backup-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service.md
@@ -115,9 +115,8 @@ Name | Type     | Required |
 #### curl Example
 
 ```bash
-curl -X POST \
+curl -X GET \
   https://<HOST-NAME>/backup/download/database/:id \
-  -H 'Content-Type: application/json' \
   -u user@domain.com:password \
   --output database.tgz
 ```
@@ -138,9 +137,8 @@ Name | Type     | Required |
 #### curl Example
 
 ```bash
-curl -X POST \
+curl -X GET \
   https://<HOST-NAME>/backup/download/volume/:id \
-  -H 'Content-Type: application/json' \
   -u user@domain.com:password \
   --output volume.tgz
 ```


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LRDOCS-7514

Seems like we're good to push this change for now. Replaces the calls to download API with `GET` requests instead of `POST` requests.