### PR TITLE
Fix 2 broken links on commerce landing page

### DIFF
--- a/docs/commerce/2.x/en/landing.html
+++ b/docs/commerce/2.x/en/landing.html
@@ -149,11 +149,11 @@
 						},
 						{
 							name: 'Managing Payment Methods',
-							url: 'store-administration/managing-payment-methods.html'
+							url: 'store-administration/configuring-payment-methods/managing-payment-methods.html'
 						},
 						{
 							name: 'Managing Exchange Rates',
-							url: 'store-administration/managing-exchange-rates.html'
+							url: 'store-administration/currencies/managing-exchange-rates.html'
 						}
 					]
 				},


### PR DESCRIPTION
Reported in the KM slack channel. Updates the landing.html page manually, so let me know if there's a better way to do this.