### PR TITLE
Delete duplicate 'a' in the first sentence of article entitled Enabling Order Workflows

### DIFF
--- a/docs/commerce/2.x/en/orders-and-fulfillment/order-workflows/enabling-or-disabling-order-workflows.md
+++ b/docs/commerce/2.x/en/orders-and-fulfillment/order-workflows/enabling-or-disabling-order-workflows.md
@@ -1,6 +1,6 @@
 # Enabling or Disabling Order Workflows
 
-[Order workflows](./introduction-to-order-workflows.md) are a a channel-specific setting that, if enabled, require the buyer or seller to give internal prior approval for an order before it can be processed.
+[Order workflows](./introduction-to-order-workflows.md) are a channel-specific setting that, if enabled, require the buyer or seller to give internal prior approval for an order before it can be processed.
 
 This article documents how to enable and disable Order Workflows.
 


### PR DESCRIPTION
Originally from @andrewwilkinsonLR here: https://github.com/Alec-Shay/liferay-learn/pull/18

This fixes a typo in "Enabling or Disabling Order Workflows."