### PR TITLE
Update outdated API, and replace placeholder in URL to be more clear

### DIFF
--- a/docs/dxp-cloud/latest/en/platform-services/backup-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service.md
@@ -84,7 +84,7 @@ Here's an example that uses token authentication with the upload API:
 
 ```bash
 curl -X POST \
-  http://<HOST-NAME>/backup/upload \
+  https://backup-<PROJECT-NAME>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
   -H 'dxpcloud-authorization: Bearer <USER_TOKEN>' \
   -F 'database=@/my-folder/database.tgz' \
@@ -116,7 +116,7 @@ Name | Type     | Required |
 
 ```bash
 curl -X GET \
-  https://<HOST-NAME>/backup/download/database/:id \
+  https://backup-<PROJECT-NAME>.lfr.cloud/backup/download/database/:id \
   -u user@domain.com:password \
   --output database.tgz
 ```
@@ -138,7 +138,7 @@ Name | Type     | Required |
 
 ```bash
 curl -X GET \
-  https://<HOST-NAME>/backup/download/volume/:id \
+  https://backup-<PROJECT-NAME>.lfr.cloud/backup/download/volume/:id \
   -u user@domain.com:password \
   --output volume.tgz
 ```
@@ -200,7 +200,7 @@ Name       | Type   | Required |
 
 ```bash
 curl -X POST \
-  http://<HOST-NAME>/backup/upload \
+  https://backup-<PROJECT-NAME>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
   -F 'database=@/my-folder/database.tgz' \
   -F 'volume=@/my-folder/volume.tgz' \

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -63,7 +63,7 @@ Run this command to invoke the API and upload the zipped files:
 
 ```bash
 curl -X POST /
-  http://<HOST-NAME>/projects/<PROJECT-NAME>/services/backup/upload /
+  https://backup-<PROJECT-NAME>.lfr.cloud/backup/upload /
   -H 'Content-Type: multipart/form-data' /
   -F 'database=@/my-folder/database.tgz' /
   -F 'volume=@/my-folder/volume.tgz' /


### PR DESCRIPTION
Updating and helping clarify API so that it's easier to tell what you should be substituting in.

Also, side-note: I noticed, as I was updating these two separate articles, that, for the end-line character for commands spanning multiple lines, in one article we use backslashes, and in the other we use forward-slashes. Is there any direction we have a direction we'd rather standardize those in?