### PR TITLE
Fix commands to dump and zip up database

### DIFF
--- a/docs/dxp-cloud/latest/en/platform-services/backup-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service.md
@@ -158,7 +158,7 @@ you must follow these steps:
 To create a MySQL dump file, run this command: 
 
 ```bash
-mysqldump -uroot -ppassword --databases --add-drop-database lportal | tar -czvf database.tgz
+mysqldump -uroot -ppassword --databases --add-drop-database lportal | gzip -c | cat > database.gz
 ```
 
 The `databases` and `add-drop-database` options are necessary for backup 
@@ -202,7 +202,7 @@ Name       | Type   | Required |
 curl -X POST \
   https://backup-<PROJECT-NAME>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
-  -F 'database=@/my-folder/database.tgz' \
+  -F 'database=@/my-folder/database.gz' \
   -F 'volume=@/my-folder/volume.tgz' \
   -u user@domain.com:password
 ```

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -18,7 +18,7 @@ This step should be done when the database is not being updated in order to prev
 Begin by exporting the data to a database dump. The export from MySQL can be accomplished using the following command:
 
 ```bash
-mysqldump -uroot -ppassword --databases --add-drop-database lportal | tar -czvf database.tgz
+mysqldump -uroot -ppassword --databases --add-drop-database lportal | gzip -c | cat > database.gz
 ```
 
 ```important::
@@ -51,7 +51,7 @@ Run this command to invoke the API and upload the zipped files:
 curl -X POST \
   https://backup-<PROJECT-NAME>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
-  -F 'database=@/my-folder/database.tgz' \
+  -F 'database=@/my-folder/database.gz' \
   -F 'volume=@/my-folder/volume.tgz' \
   -u user@domain.com:password
 ```


### PR DESCRIPTION
As pointed out in a thread in Slack, you can't pipe into a tar command the way we had in our documentation. I tested this command so it does work (and I confirmed with the engineers the upload API should still support the different format of zip file).