### PR TITLE
Update build.gradle for model listener article

### DIFF
--- a/docs/dxp/7.x/en/liferay-internals/extending-liferay/creating-a-model-listener/liferay-n4g6.zip/n4g6-impl/build.gradle
+++ b/docs/dxp/7.x/en/liferay-internals/extending-liferay/creating-a-model-listener/liferay-n4g6.zip/n4g6-impl/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "5.4.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "6.0.0"
 	compileOnly group: "com.liferay.portal", name: "release.portal.api", version: "7.1.1"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"


### PR DESCRIPTION
An update to the portal kernel version in `7.3.1-ga2` broke the sample module for this article (and likely other articles). May need to update other sample modules as well at some point, but did confirm this version fixes it for this module.