### PR TITLE
404 fix

### DIFF
--- a/site/docs/conf.py
+++ b/site/docs/conf.py
@@ -24,6 +24,7 @@ html_title = "Liferay Learn"
 language = "en"
 locale_dirs = ["_locale"]
 master_doc = "contents"
+notfound_no_urls_prefix = True
 notfound_template = "404.html"
 project = "Liferay Learn"
 release = "1.0"

--- a/site/homepage/conf.py
+++ b/site/homepage/conf.py
@@ -20,6 +20,7 @@ html_title = "Liferay Learn"
 language = "en"
 locale_dirs = ["_locale"]
 master_doc = "contents"
+notfound_no_urls_prefix = True
 notfound_template = "404.html"
 project = "Liferay Learn"
 release = "1.0"


### PR DESCRIPTION
I can't test this one locally, but I noticed the resources weren't being found since they had a `/en/latest` url prefix in front of `_static`. I'm not sure how those are added, but there is a `notfound_no_urls_prefix` configuration that removes the `/en/latest` portion and the css/js should be properly loaded.