### PR TITLE
Clustering followup

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/clustering-for-high-availability.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/clustering-for-high-availability.md
@@ -24,7 +24,7 @@ After you've configured your DXP cluster, you can deploy applications to it and 
 
 ## What's Next
 
-Creating a cluster by way of example is a great first step in understanding DXP clustering. Start with [Example: Creating a Simple DXP Cluster](./example-creating-a-simple-dxp-cluster) to learn more. Then address the [Clustering Requirements](#clustering-requirements) listed above.
+Creating a cluster by way of example is a great first step in understanding DXP clustering. Start with [Example: Creating a Simple DXP Cluster](./example-creating-a-simple-dxp-cluster.md) to learn more. Then address the [Clustering Requirements](#clustering-requirements) listed above.
 
 ```note::
    This documentation describes DXP-specific cluster configuration without getting into specific implementations of third party software, such as Java EE application servers, HTTP servers, and load balancers. Please consult the documentation for those components to configure them. Before creating a DXP cluster, make sure your OS is not defining the hostname of your system to the local network at 127.0.0.1.

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
@@ -97,7 +97,7 @@ Congratulations! Your cluster is using Cluster Link.
 
 ## What's Next
 
-It's best to test your DXP cluster under load and investigate optimizing your system. DXP's cache is a good place to start optimizing. You can configure cache for Liferay entities and entities you've created using Service Builder. For information on configuring entity cache, please see [Cache Configuration](https://help.liferay.com/hc/en-us/articles/360035581451-Introduction-to-Cache-Configuration).
+It's best to test your DXP cluster under load and investigate optimizing your system. Consider the entities used most on your site and adjust their cache settings appropriately. For information on configuring cache, please see [Cache Configuration](https://help.liferay.com/hc/en-us/articles/360035581451-Introduction-to-Cache-Configuration).
 
 ## Additional Information
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
@@ -58,33 +58,30 @@ Please see [JGroups's documentation](http://www.jgroups.org/manual4/index.html#p
 
 Multicast broadcasts to all devices on the network. Clustered environments on the same network communicate with each other by default. Messages and information (e.g., scheduled tasks) sent between them can lead to unintended consequences. Isolate such cluster environments by either separating them logically or physically on the network, or by configuring each cluster's `portal-ext.properties` to use different sets of [multicast group address and port values](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Multicast).
 
-JGroups sets a bind address automatically, using `localhost` by default. If you want to set a manual address, you can set it in `portal-ext.properties`:
-
-```properties
-cluster.link.bind.addr["cluster-link-control"]=localhost
-cluster.link.bind.addr["cluster-link-udp"]=localhost
-```
-
-In some configurations, however, `localhost` is bound to the internal loopback network (`127.0.0.1` or `::1`), rather than the host's real address. If for some reason you need this configuration, you can make DXP automatically detect its real address with this property:
+JGroups sets a bind address automatically, using `localhost` by default. In some configurations, however, `localhost` is bound to the internal loopback network (`127.0.0.1` or `::1`), rather than the host's real address. As long as DXP's `cluster.link.autodetect.address` Portal Property points to a server that's contactable, DXP uses that server to automatically detect your host's real address. Here's the default setting:
 
 ```properties
 cluster.link.autodetect.address=www.google.com:80
 ```
 
-Set it to connect to some other host that's contactable by your server. By default, it points to Google, but this may not work if your server is behind a firewall. If you set the address manually using the properties above, you don't need to set the auto-detect address.
+Contacting Google may not work if your server is behind a firewall.
 
-Your network configuration may preclude the use of multicast over TCP, so below are some other ways you can get your cluster communicating. Note that these methods are all provided by JGroups.
+An alternative to detecting the host address automatically for the bind address, you can set the bind address manually in your `portal-ext.properties` file.
 
-### Test Your Cluster Link Configuration
-
-1. If you are binding the IP address instead of using `localhost`, make sure the right IP addresses are declared using these properties:
+1. Disable address auto-detection by setting the `cluster.link.autodetect.address` property to an empty value:
 
     ```properties
-    cluster.link.bind.addr["cluster-link-control"]=localhost
-    cluster.link.bind.addr["cluster-link-udp"]=localhost
+    cluster.link.autodetect.address=
     ```
 
-1. Test your load and then optimize your settings if necessary.
+2. Set the following properties to your host's IP address:
+
+    ```properties
+    cluster.link.bind.addr["cluster-link-control"]=[place your IP address here]
+    cluster.link.bind.addr["cluster-link-udp"]=[place your IP address here]
+    ```
+
+Your network configuration may preclude the use of multicast over TCP, so below are some other ways you can get your cluster communicating. Note that these methods are all provided by JGroups.
 
 ## Conclusion
 
@@ -100,7 +97,7 @@ Congratulations! Your cluster is using Cluster Link.
 
 ## What's Next
 
-It's best to test your DXP cluster under load and investigate optimizing your system. DXP's cache is a good place to start optimizing. You can configure cache for Liferay entities and entities you've created using Service Builder. For information on configuring cache for these entities, please see [Cache Configuration](https://help.liferay.com/hc/en-us/articles/360035581451-Introduction-to-Cache-Configuration).
+It's best to test your DXP cluster under load and investigate optimizing your system. DXP's cache is a good place to start optimizing. You can configure cache for Liferay entities and entities you've created using Service Builder. For information on configuring entity cache, please see [Cache Configuration](https://help.liferay.com/hc/en-us/articles/360035581451-Introduction-to-Cache-Configuration).
 
 ## Additional Information
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link.md
@@ -98,6 +98,10 @@ GMS: address=oz-52865, cluster=liferay-channel-control, physical address=192.168
 
 Congratulations! Your cluster is using Cluster Link.
 
+## What's Next
+
+It's best to test your DXP cluster under load and investigate optimizing your system. DXP's cache is a good place to start optimizing. You can configure cache for Liferay entities and entities you've created using Service Builder. For information on configuring cache for these entities, please see [Cache Configuration](https://help.liferay.com/hc/en-us/articles/360035581451-Introduction-to-Cache-Configuration).
+
 ## Additional Information
 
 * [Configuring Unicast over TCP](./configuring-unicast-over-tcp.md)

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-unicast-over-tcp.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-unicast-over-tcp.md
@@ -60,7 +60,7 @@ Use the following steps to configure Unicast:
         -Djgroups.tcpping.initial_hosts=192.168.224.154[7800],192.168.224.155[7800]
         ```
 
-1. Copy your `tcp.xml` file to each node, making sure to set the TCP bind port to the node's bind port. On the node with IP address `192.168.224.155`, for example, configure TCPPing like this:
+1. Copy your `tcp.xml` file to the same location on each node, making sure to set the TCP bind port to an unused port on each node. On the node with IP address `192.168.224.155`, for example, configure TCPPing like this:
 
     ```xml
     <TCP bind_port="7800"/>
@@ -69,7 +69,7 @@ Use the following steps to configure Unicast:
         port_range="0"/>
     ```
 
-1. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in each node's `portal-ext.properties` file to enable Cluster Link and point to the TCP XML file for each Cluster Link channel:
+1. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in each node's [`portal-ext.properties` file](../../reference/portal-properties.md) to enable Cluster Link and point to the TCP XML file for each Cluster Link channel:
 
     ```properties
     cluster.link.enabled=true
@@ -91,7 +91,7 @@ TCP Ping is the default discovery protocol you can use to fit a majority of use 
 
 ### JDBC Ping
 
-Rather than use TCP Ping to discover cluster members, you can use a central database accessible by all the nodes to help them find each other. Cluster members write their own and read the other members' addresses from this database. To enable this configuration, replace the `TCPPING` tag with the corresponding `JDBC_PING` tag:
+Rather than use TCP Ping to discover cluster members, you can use a central database accessible by all the nodes to help them find each other. Cluster members write their own and read the other members' addresses from this database. To enable this configuration, replace the `TCPPING` tag referenced in the [Unicast Configuration](#unicast-configuration) steps with the corresponding `JDBC_PING` tag:
 
 ```xml
 <JDBC_PING
@@ -107,7 +107,7 @@ For example JDBC connection values, please see [Database Templates](../../refere
 
 Amazon S3 Ping can be used for servers running on Amazon's EC2 cloud service. Each node uploads a small file to an S3 bucket, and all the other nodes read the files from this bucket to discover the other nodes. When a node leaves, its file is deleted.
 
-To configure S3 Ping, replace the `TCPPING` tag with the corresponding `S3_PING` tag:
+To configure S3 Ping, replace the `TCPPING` tag in the [Unicast Configuration](#unicast-configuration) steps with the corresponding `S3_PING` tag:
 
 ```xml
 <S3_PING
@@ -141,7 +141,7 @@ The following steps use Unicast over TCPPing to demonstrate the approach.
     * `tcp-control.xml`
     * `tcp-transport.xml`
 
-1. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in the node's `portal-ext.properties` file to enable Cluster Link and point to the TCP XML file for each Cluster Link channel:
+1. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in the node's [`portal-ext.properties` file](../../reference/portal-properties.md) to enable Cluster Link and point to the TCP XML file for each Cluster Link channel:
 
     ```properties
     cluster.link.enabled=true
@@ -149,7 +149,7 @@ The following steps use Unicast over TCPPing to demonstrate the approach.
     cluster.link.channel.properties.transport.0=/jgroups/tcp-transport.xml
     ```
 
-1. Modify each `tcp-*.xml` file's TCP and TCPPing elements to account for each node's IP address and bind port.
+1. Modify each `tcp-*.xml` file's TCP and discovery protocol tags (e.g., `TCPPing` tag if you're using TCPPing) to account for each node's IP address and bind port.
 
 If you're vertically clustering (i.e., you have multiple servers running on the same physical or virtual system), every channel must use a unique unused bind port for discovery communication. In each `tcp-*.xml` file, assign the TCP tag's `bind_port` attribute to a unique, unused port.
 
@@ -200,7 +200,7 @@ Here are example TCP and TCPPing elements using the bind ports on nodes running 
     port_range="0"/>
 ```
 
-If you have added entities that can be cached or you want to tune the cache configuration for your system, you can do so using a module.
+If you have added entities that can be cached or you want to tune the cache configuration for your system, you can do so using a module. <!--TODO Link to caching articles. jhinkey -->
 
 ## Additional Information
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/database-configuration-for-cluster-nodes.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/database-configuration-for-cluster-nodes.md
@@ -16,7 +16,7 @@ Connections to separate read and read-write [data sources](https://docs.liferay.
 
 ### JDBC
 
-Follow these steps to use [JDBC](../../installing-liferay/configuring-a-database.md) to connect directly to your read and write data sources:
+Edit your `portal-ext.properties` file following these steps to connect directly to your separate read and write data sources using [JDBC](../../installing-liferay/configuring-a-database.md):
 
 1. Set the default connection pool provider. For provider information, see the [JDBC properties reference](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#JDBC). The default setting specifies [HikariCP](https://github.com/brettwooldridge/HikariCP) as the pool provider:
 
@@ -40,37 +40,37 @@ Follow these steps to use [JDBC](../../installing-liferay/configuring-a-database
 
     For example JDBC connection values, please see [Database Templates](../../reference/database-templates.md).
 
-1. Apply the following setting so that DXP uses the write data source (the data source whose prefix is `jdbc.write.`) to create the [Counter](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Counter) data source. A separate data source is always dedicated to the counter.
+1. Configure DXP to use the write data source (the data source whose prefix is `jdbc.write.`) to create the [Counter](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Counter) data source. A separate data source is always dedicated to the counter.
 
     ```properties
     counter.jdbc.prefix=jdbc.write.
     ```
 
-1. Validating a database connection before using it, lets you handle bad connections gracefully. Validation is optional and might have a small cost, but avoids bad connections.
+1. Optionally validate the data connections to make sure bad connections are handled gracefully.
 
     Some connection pools used with JDBC4 (check your driver's JDBC version) validate connections automatically. Other connection pools may require additional, vendor-specific connection validation properties---specify them in a Portal Properties file. Refer to your connection pool provider documentation for connection validation details.
 
-1. Enable the read-writer database configuration by uncommenting the following Spring configuration files from the `spring.configs` and `spring.infrastructure.configs` properties:
+1. Enable the read-writer database configuration by copying the default [`spring.configs` and `spring.infrastructure.configs` Portal Properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Spring) to your `portal-ext.properties` file and adding the following Spring configuration file paths to them.
 
-    ```properties
-    spring.configs=\
-        [..]
-        META-INF/dynamic-data-source-spring.xml,\
-        [..]
+    Add to `spring.configs`:
 
-    spring.infrastructure.configs=\
-        [..]
-        META-INF/dynamic-data-source-infrastructure-spring.xml,\
-        [..]
+    ```
+        META-INF/dynamic-data-source-spring.xml
+    ```
+
+    Add to `spring.infrastructure.configs`:
+
+    ```
+    META-INF/dynamic-data-source-infrastructure-spring.xml
     ```
 
     For more information, see the [Spring configuration Portal Properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Spring).
 
 ### JNDI
 
-Follow these steps to use JNDI to connect to your read and write data sources on your app server:
+Edit your `portal-ext.properties` file following these steps to connect to your read and write data sources on your app server using JNDI:
 
-1. Set your read and write JNDI data source usernames and passwords.
+1. Set your read and write JNDI data source user names and passwords.
 
     ```properties
     jdbc.read.jndi.name=[place your "read" data source JNDI name here]
@@ -84,28 +84,28 @@ Follow these steps to use JNDI to connect to your read and write data sources on
     jdbc.write.password=[place your password here]
     ```
 
-1. Apply the following setting so that DXP uses the write data source (the data source whose prefix is `jdbc.write.`) to create the [Counter](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Counter) data source. A separate data source is always dedicated to the counter.
+1. Configure DXP to use the write data source (the data source whose prefix is `jdbc.write.`) to create the [Counter](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Counter) data source. A separate data source is always dedicated to the counter.
 
     ```properties
     counter.jdbc.prefix=jdbc.write.
     ```
 
-1. Validating a database connection before using it, lets you handle bad connections gracefully. Validation is optional and might have a small cost, but avoids bad connections.
+1. Optionally validate the data connections to make sure bad connections are handled gracefully.
 
     Some connection pools used with JDBC4 (check your driver's JDBC version) validate connections automatically. Other connection pools may require additional, vendor-specific connection validation properties---specify them in a Portal Properties file. Refer to your connection pool provider documentation for connection validation details.
 
-1. Enable the read-writer database configuration by uncommenting the following Spring configuration files from the `spring.configs` and `spring.infrastructure.configs` properties:
+1. Enable the read-writer database configuration by copying the default [`spring.configs` and `spring.infrastructure.configs` Portal Properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Spring) to your `portal-ext.properties` file and adding the following Spring configuration file paths to them.
 
-    ```properties
-    spring.configs=\
-        [..]
-        META-INF/dynamic-data-source-spring.xml,\
-        [..]
+    Add to `spring.configs`:
 
-    spring.infrastructure.configs=\
-        [..]
-        META-INF/dynamic-data-source-infrastructure-spring.xml,\
-        [..]
+    ```
+        META-INF/dynamic-data-source-spring.xml
+    ```
+
+    Add to `spring.infrastructure.configs`:
+
+    ```
+    META-INF/dynamic-data-source-infrastructure-spring.xml
     ```
 
     For more information, see the [Spring configuration Portal Properties](https://docs.liferay.com/portal/7.3-latest/propertiesdoc/portal.properties.html#Spring).
@@ -114,7 +114,7 @@ DXP uses a read data source, a write data source, and a counter data source the 
 
 ## Database Replication
 
-Using a database cluster improves fault tolerance and DXP performance. Database cluster instances must be stay in sync. Replication is the process of copying changed data and changed schema from one database instance to another. All supported databases support replication. If you're using a database cluster, set up the databases for replication by following the database vendor's instructions.
+Using a database cluster improves fault tolerance and DXP performance. Database cluster instances must be stay in sync. Replication is the process of copying changed data and changed schema from one database instance to another. All [supported databases](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.2+Compatibility+Matrix/b6e0f064-db31-49b4-8317-a29d1d76abf7) support replication. If you're using a database cluster, set up the databases for replication by following the database vendor's instructions.
 
 ## What's Next
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/example-creating-a-simple-dxp-cluster.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/example-creating-a-simple-dxp-cluster.md
@@ -27,6 +27,10 @@ Here are the steps for creating the cluster:
 1. [Front the Cluster with a Web Server](#front-the-cluster-with-a-web-server)
 1. [Test the Cluster](#test-the-cluster)
 
+```important::
+    Don't have Docker? Go here first: `Linux <https://docs.docker.com/install/linux/docker-ce/ubuntu/>`_ | `Windows <https://docs.docker.com/docker-for-windows/install/>`_ | `OSX <https://docs.docker.com/docker-for-mac/install/>`_
+```
+
 ```note::
    DXP cluster environments can also be set up using an `on-premises DXP Tomcat bundle <../../installing-liferay/installing-a-liferay-tomcat-bundle.md>`_, using `DXP installed to an app server <../../installing-liferay/installing_liferay_on_an_application_server.md>`_ on-premises, or using any combination of Docker containers and DXP installations.
 ```
@@ -179,12 +183,12 @@ Here's a summary of the items to configure:
 
 | Item | Configuration Method |
 | :--- | :---------- |
-| Search engine connection | Configuration file |
+| Search engine connection | [Configuration file](../../../system-administration/system-settings/using-configuration-files.md) |
 | Data source connection | `portal-ext.properties` file | See [Database Templates](../../reference/database-templates.md) |
 | File Store connection | `portal-ext.properties` file. Some File Store types require a configuration file too. | See [Configuring a File Store](../../..//system-administration/file-storage/configuring-file-storage.md) |
 | Cluster Link | `portal-ext.properties` file | See [Configuring Cluster Link](./configuring-cluster-link.md) |
 
-The Portal Properties can be specified using Docker environment variables or a `portal-ext.properties` file. Since this example uses several properties, properties files are used.
+The [Portal Properties](../../reference/portal-properties.md) can be specified using Docker environment variables or a `portal-ext.properties` file. Since this example uses several properties, properties files are used.
 
 One way to organize your node configurations is to create a folder for each node:
 
@@ -196,7 +200,7 @@ You're ready to configure the DXP server nodes.
 
 ### Configure the Search Engine Connection
 
-1. Create a search engine configuration file:
+1. Create a search engine [configuration file](../../../system-administration/system-settings/using-configuration-files.md):
 
     Create an `/osgi/config/` folder.
 
@@ -417,7 +421,7 @@ The DXP cluster node containers will have this configuration:
 | OSGi container port mapping | ``11311:11311`` | `11312:11311` |
 | Volume bind mount | `${PWD}/dxp-1/files:/mnt/liferay` | `${PWD}/dxp-2/files:/mnt/liferay` |
 
-The port mappings are from the host port to the container port. The host ports are unique to avoid collisions between them on the host. The container ports need only be unique within each container, and can therefore be the same on each node (e.g., each container uses the `8080` as its web server HTTP port). Remember that the example proxy server and load balancer directs requests to each container via each container's HTTP port. Here's an excerpt from the proxy configuration:
+The host ports are mapped to container ports. The unique host ports prevent collisions on the host. The container ports need only be unique within each container, and can therefore be the same on each node (e.g., each container uses the `8080` as its web server HTTP port). Remember that the example proxy server and load balancer directs requests to containers via each container's HTTP port. Here's a proxy configuration excerpt from the `httpd.conf` file:
 
 ```xml
   ...
@@ -429,7 +433,7 @@ The port mappings are from the host port to the container port. The host ports a
   ...
 ```
 
-The OSGi container mapping is for using Gogo shell on each container. The volume bind mount, leverages the DXP container's configuration phase to copy the `portal-ext.properties` files to the DXP server's [Liferay Home](../../reference/liferay-home.md).
+In the table above, the OSGi container port mapping is for using Gogo shell on each container. The volume bind mount, leverages the DXP container's configuration phase to copy the `portal-ext.properties` files to the DXP server's [Liferay Home](../../reference/liferay-home.md).
 
 It's time to start the DXP cluster nodes:
 
@@ -487,7 +491,7 @@ DXP is available at <http://localhost>. The web server directs your request to t
 
 ### Test the Cluster
 
-Test your cluster to make sure they show the same content changes and that DXP stays available when there is at least one cluster node running.
+Test your cluster to make sure the nodes show the same content changes and that DXP stays available when there is at least one cluster node running.
 
 Start by adding content (e.g., the Language Selector widget) to your site at <http://localhost>.
 


### PR DESCRIPTION
Followed up on these items

- In Example, add note on Docker desktop requirement.
- Smoothed out steps. Example, in read-writer database spring configs.
- In Cluster Link, consolidate bind address content and correct the content as setting bind addresses explicitly requires disabling the a address autodetect property.
- At the end of the Cluster Link article, I added a paragraph mentioning and linking to Cache Configuration. This is especially important because Cluster Link's goal is to support keeping cache in sync between nodes.
- Clarified how unicast TCP discovery protocols can be leveraged by replacing the TCPPing element in the Unicast configuration steps.