### PR TITLE
Add Sphinx to build script

### DIFF
--- a/site/build_site.sh
+++ b/site/build_site.sh
@@ -185,9 +185,9 @@ function main {
 
 	source venv/bin/activate
 
-	check_utils pip3 sphinx-build zip
+	check_utils pip3 zip
 
-	pip_install recommonmark sphinx-intl sphinx-copybutton sphinx-markdown-tables sphinx-notfound-page
+	pip_install sphinx recommonmark sphinx-intl sphinx-copybutton sphinx-markdown-tables sphinx-notfound-page
 
 	parse_args_generate_sphinx_input $1 $2
 


### PR DESCRIPTION
The assumption was being made in the script that Sphinx was installed separately, because it checked first for the presence of `sphinx-build`. I removed that check and added Sphinx to the install line. @rbohl