### PR TITLE
LRDOCS-7743

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
@@ -37,7 +37,7 @@ in the service's `LCP.json`:
 
 ```json
 {
-  "id": "liferay",
+  "id": "webserver",
   "loadBalancer": {
     "customDomains": ["acme.com", "www.acme.com"]
   }


### PR DESCRIPTION
Quick fix as pointed out on [LRDOCS-7743](https://issues.liferay.com/browse/LRDOCS-7743); the service ID is wrong, when the configuration should be in the web server's `LCP.json`.