### PR TITLE
Fix code block highlighting errors

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-setup-example.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-setup-example.md
@@ -12,7 +12,7 @@ To configure an IPsec test server:
 
 1. Save the following file as `~/ipsec.conf` and replace the `leftid` value with your VPN server's external IP.
 
-    ```properties
+    ```
     config setup
       charondebug="ike 1, knl 1, cfg 0"
       uniqueids=no
@@ -137,7 +137,7 @@ Follow these steps if using an OpenVPN server:
 
 1. Create a `~/server.conf` with the following values:
 
-    ```properties
+    ```
     #Port where the VPN server will answer requests
     port 1194
 

--- a/docs/dxp/7.x/en/headless-delivery/content-delivery-apis/consuming-graphql-apis.md
+++ b/docs/dxp/7.x/en/headless-delivery/content-delivery-apis/consuming-graphql-apis.md
@@ -30,7 +30,7 @@ This URL does not require authentication, but calling any API does. The JSON ret
 
 The `BlogPosting` API looks like this:
 
-```graphql
+```
 createSiteBlogPosting(
   blogPosting: InputBlogPosting
   siteKey: String!
@@ -100,7 +100,7 @@ The GraphQL schema revealed the call that must be made to post a blog entry.
 
 1. Construct the GraphQL query based on the schema documentation:
 
-   ```graphql
+   ```
    mutation CreateBlog($blog: InputBlogPosting){
      createSiteBlogPosting(blogPosting: $blog, siteKey: "20119" ) {
        headline
@@ -140,7 +140,7 @@ Note that a GraphQL client makes the job of calling APIs easier, because it can 
 
 The first call you made called this API:
 
-```graphql
+```
 blogPostings (
    filter:String
    page: Int
@@ -182,7 +182,7 @@ Now Liferay DXP returns JSON containing the data you requested:
 
 The API call from the GraphQL schema for getting a single Blog entry has only one parameter:
 
-```graphql
+```
 blogPosting(
    blogPostingId: Long
 ): BlogPosting
@@ -212,7 +212,7 @@ This returns the same blog entry:
 
 Deleting a blog entry, like creating one, is a mutation. Its call is almost the same as getting a single blog entry:
 
-```graphql
+```
 deleteBlogPosting(
   blogPostingId: Long
 ): Boolean

--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-jboss-eap.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-jboss-eap.md
@@ -334,7 +334,7 @@ If you want to manage the mail session with JBoss, follow these steps:
 
 After deploying DXP, you may see excessive warnings and log messages such as the ones below, involving `PhaseOptimizer`. These are benign and can be ignored. Make sure to adjust the app server's logging level or log filters to avoid excessive benign log messages.
 
-```log
+```
 May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process
 WARNING: Skipping pass gatherExternProperties
 May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process

--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-tomcat.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-tomcat.md
@@ -134,7 +134,7 @@ Here are the steps:
 
 1. Provide Catalina access to the JARs in `$CATALINA_BASE/lib/ext` by opening your `$CATALINA_BASE/conf/catalina.properties` file and appending this value to the `common.loader` property:
 
-    ```properties
+    ```
     ,"${catalina.home}/lib/ext/global","${catalina.home}/lib/ext/global/*.jar","${catalina.home}/lib/ext","${catalina.home}/lib/ext/*.jar"
     ```
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-websphere.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-websphere.md
@@ -92,7 +92,7 @@ Next, in the WebSphere profile, set an argument that supports DXP's JVM requirem
 
 As a baseline, add `maximumHeapSize="2560"` inside the `jvmEntries` tag. For example:
 
-```xml
+```
 <jvmEntries xmi:id="JavaVirtualMachine_1183122130078" ... maximumHeapSize="2560">
 ```
 
@@ -120,7 +120,7 @@ In `[Install Location]/WebSphere/AppServer/profiles/your-profile/config/cells/yo
 
 If this tag is not removed, an error similar to this may occur:
 
-```log
+```
 WSVR0501E: Error creating component com.ibm.ws.runtime.component.CompositionUnitMgrImpl@d74fa901
 com.ibm.ws.exception.RuntimeWarning: com.ibm.ws.webcontainer.exception.WebAppNotLoadedException: Failed to load webapp: Failed to load webapp: SRVE8111E: The application, LiferayEAR, is trying to modify a cookie which matches a pattern in the restricted programmatic session cookies list [domain=*, name=JSESSIONID, path=/].
 ```
@@ -250,7 +250,7 @@ To validate that the mail session has been configured correctly, there are a num
 
 WebSphere restricts cookies to HTTPS sessions by default. If using HTTP, this prevents users from signing in to DXP and displays the following error in the console:
 
-```log
+```
 20:07:14,021 WARN  [WebContainer : 1][SecurityPortletContainerWrapper:341]
 User 0 is not allowed to access URL http://localhost:9081/web/guest/home and portlet com_liferay_login_web_portlet_LoginPortlet
 ```
@@ -321,7 +321,7 @@ Note that the DXP `.war` comes pre-packaged with the `ibm-web-ext.xmi` file; thi
 
 After deploying DXP, there may be excessive warnings and log messages, such as the ones below, involving `PhaseOptimizer`. These are benign and can be ignored. Make sure to adjust the app server's logging level or log filters to avoid excessive benign log messages.
 
-```log
+```
 |     May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process
 |     WARNING: Skipping pass gatherExternProperties
 |     May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process

--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-wildfly.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-wildfly.md
@@ -342,7 +342,7 @@ If you want to manage your mail session with WildFly, follow these steps:
    After deploying DXP, you may see excessive warnings and log messages, such as the ones below, involving ``PhaseOptimizer``. These are benign and can be ignored. Make sure to adjust your app server's logging level or log filters to avoid excessive benign log messages.
 ```
 
-```log
+```
 May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process
 WARNING: Skipping pass gatherExternProperties
 May 02, 2018 9:12:27 PM com.google.javascript.jscomp.PhaseOptimizer$NamedPass process

--- a/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/patching-liferay/installing-patches.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/patching-liferay/installing-patches.md
@@ -31,7 +31,7 @@ If you're patching a DXP bundle, continue with the basic patching steps below. I
 
     The output looks like this:
 
-    ```messages
+    ```
     One patch is ready to be installed. Applying dxp...
     Cleaning up: [1%..10%..20%..30%..40%..50%..60%..70%..80%..90%..100%]
     Installing patches: [1%..10%..20%..30%..40%..50%..60%..70%..80%..90%...100%]
@@ -46,7 +46,7 @@ If you're patching a DXP bundle, continue with the basic patching steps below. I
 
     The output lists the currently installed patches:
 
-    ```messages
+    ```
     Loading product and patch information...
     Product information:
       * installation type: binary

--- a/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/securing-web-services/setting-service-access-policies.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/securing-web-services/setting-service-access-policies.md
@@ -51,7 +51,7 @@ For example, `com.liferay.portal.kernel.service.UserService` allows any method f
 
 The following example allows any method from the `UserService` class to be invoked and any method from the `DLAppService` whose name starts with `get` to be invoked:
 
-```java
+```
 com.liferay.portal.kernel.service.UserService
 com.liferay.document.library.kernel.service.DLAppService#get*
 ```

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/example-creating-a-simple-dxp-cluster.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/example-creating-a-simple-dxp-cluster.md
@@ -368,7 +368,7 @@ This example fronts the application server cluster with an [Apache Web Server](h
 
 1. Configure the request proxy and load balancing (using Apache's [`byrequests` method](https://httpd.apache.org/docs/2.4/mod/mod_lbmethod_byrequests.html)), by adding the [`VirtualHost` element](https://httpd.apache.org/docs/2.4/vhosts/) to the end of `httpd.conf` file:
 
-    ```xml
+    ```
     <VirtualHost *:80>
       ProxyRequests off
       ProxyPass / balancer://liferaycluster/
@@ -423,7 +423,7 @@ The DXP cluster node containers will have this configuration:
 
 The host ports are mapped to container ports. The unique host ports prevent collisions on the host. The container ports need only be unique within each container, and can therefore be the same on each node (e.g., each container uses the `8080` as its web server HTTP port). Remember that the example proxy server and load balancer directs requests to containers via each container's HTTP port. Here's a proxy configuration excerpt from the `httpd.conf` file:
 
-```xml
+```
   ...
   <Proxy balancer://liferaycluster>
     BalancerMember "http://dxp-1:8080" route=liferay1

--- a/docs/dxp/7.x/en/liferay-internals/extending-liferay/creating-a-model-listener.md
+++ b/docs/dxp/7.x/en/liferay-internals/extending-liferay/creating-a-model-listener.md
@@ -25,7 +25,7 @@ First, deploy an example model listener for the `JournalArticle` model on your i
 
 1. Download and unzip `Acme Model Listener`.
 
-    ```curl
+    ```bash
     curl https://learn.liferay.com/dxp-7.x/liferay-internals/extending-liferay/liferay-n4g6.zip -O
     ```
 

--- a/docs/dxp/7.x/en/using-search/search-pages-and-widgets/search-results/sorting-search-results.md
+++ b/docs/dxp/7.x/en/using-search/search-pages-and-widgets/search-results/sorting-search-results.md
@@ -55,7 +55,7 @@ To find the fields available for use in the Sort widget, Users with the proper p
 
 If you really must sort by a `text` field, add a new version of the field to the index with the type `keyword`. From the field mappings screen mentioned above, look at the `firstName` field in the index called `liferay-[companyID]`: 
 
-```json
+```
 "firstName" : {
     "type" : "text",
     "store" : true


### PR DESCRIPTION
In the list of build errors that come up when running `./build_site.sh` (and there are many), I observed the following biggest culprits (most notable when they create giant walls of errors at a time):

- **Empty RSTs.** These are largely in place as placeholders (as we discussed previously). I did not touch these as they appear to be intentional.
- **Errors in README.rsts.** While some of these may be a simple typo, from a look over some of them, I'm noticing that many of them look like they just aren't being updated together with files being moved/replaced at all (e.g., the files are either moved to totally different locations or no longer even exist). Since there were so many -- and since we have also been having discussions lately about the validity of having these READMEs even around in the first place -- I ended up setting these aside for now. I can still look at these if desired, but I stopped with them for now because I wasn't sure if it would be a valuable use of time.
- **Errors with code blocks that do not conform to their respective languages.** These errors are either due to being mislabeled (i.e., a lexer that does not exist), or because we are putting content in them that doesn't exactly match the syntax the `Pygments` plugin would need to actually leverage the syntax highlighting. This PR is focused on these errors.

In most cases, I assumed that we do not want to change the content, because the difference is intentional (for example, we might have a block labeled `properties`, which we have in a special format that differs from the rigid way Sphinx would parse it). Since this means it won't be able to use the highlighting, in most of these cases I addressed these errors by just removing the language altogether.

Please let me know if there are any concerns or objections to any of these changes. Thank you.