### PR TITLE
Add non-GitHub options to Development Requirements article

### DIFF
--- a/docs/dxp-cloud/latest/en/getting-started/development-requirements.md
+++ b/docs/dxp-cloud/latest/en/getting-started/development-requirements.md
@@ -14,7 +14,13 @@ In order to set up a local environment for development with DXP Cloud, the follo
 
 * [Git](https://git-scm.com/): necessary for adding changes to deploy to DXP Cloud
 
-* [GitHub Account](https://github.com/): required for pushing code changes to GitHub and sending pull requests
+* Repository hosting account: required to push code changes to GitHub and submit changes. You can use an account for any of these available options:
+
+    * [GitHub](https://github.com/)
+
+    * [Bitbucket](https://bitbucket.org/)
+
+    * [GitLab](https://gitlab.com/)
 
     ```note::
        Liferay DXP Cloud has similar prerequisites to `Liferay Workspace <https://help.liferay.com/hc/en-us/articles/360029147471-Liferay-Workspace>`_. Developers who are familiar with creating a Liferay Workspace using `Liferay Dev Studio <https://customer.liferay.com/downloads?p_p_id=com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_productAssetCategoryId=118191007&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_fileTypeAssetCategoryId=118191038>`_, `Maven <https://help.liferay.com/hc/en-us/articles/360017885592-Maven-Workspace>`_, or the `Liferay IntelliJ Plugin <https://plugins.jetbrains.com/plugin/10739-liferay-intellij-plugin>`_ will have most of the necessary tools already set up.
@@ -22,6 +28,8 @@ In order to set up a local environment for development with DXP Cloud, the follo
 
 ## Additional Information
 
-* [Configuring Github Repo](../getting-started/configuring-your-github-repository.md)
+* [Configuring Your Github Repository](../getting-started/configuring-your-github-repository.md)
+* [Configuring Your Bitbucket Repository](./configuring-your-bitbucket-repository.md)
+* [Configuring Your GitLab Repository](./configuring-your-gitlab-repository.md)
 * [Overview of the DXP Cloud Deployment Workflow](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md)
 * [Logging Into Your Liferay DXP Instance](../getting-started/logging-into-your-dxp-cloud-services.md)


### PR DESCRIPTION
This is a minor update to the Development Requirements article, to make sure it lists out all the options available now for repository hosting, not just GitHub.