### PR TITLE
Convert to adominitions

### DIFF
--- a/docs/commerce/2.x/en/account-management/commerce-roles-permissions-reference.md
+++ b/docs/commerce/2.x/en/account-management/commerce-roles-permissions-reference.md
@@ -2,7 +2,9 @@
 
 Liferay Commerce offers four Commerce [account roles](./account-roles.md) out of the box: Account Administrator, Buyer, Order Manager, and Sales Agent. This article serves as a reference for the specific permissions keys associated with each role.
 
-> **Note:** These permission keys may change in future updates.
+```note::
+   These permission keys may change in future updates.
+```
 
 To view the permissions associated with each Commerce account role:
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-discount-rule-type.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-discount-rule-type.md
@@ -38,7 +38,9 @@ First, you must deploy an example discount rule type on your instance of Liferay
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Liferay Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-product-data-source-for-the-product-publisher-widget.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-product-data-source-for-the-product-publisher-widget.md
@@ -38,7 +38,9 @@ In this section, we will get an example product data source up and running on yo
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Liferay Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-product-type.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/adding-a-new-product-type.md
@@ -38,7 +38,9 @@ In this section, we will get an example product type up and running on your inst
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Liferay Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-checkout-step.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-checkout-step.md
@@ -38,7 +38,9 @@ In this section, we will get an example checkout step up and running on your ins
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 
@@ -58,7 +60,9 @@ Next, let's dive deeper to learn more.
 
 In this section, we will review the example we deployed. First, we will annotate the class for OSGi registration. Second, we will review the `CommerceCheckoutStep` interface. And third, we will complete our implementation of `CommerceCheckoutStep`.
 
-> **Note:** To simplify implementing `CommerceCheckoutStep`, we extend `BaseCommerceCheckoutStep` for its base functionality.
+```note::
+   To simplify implementing ``CommerceCheckoutStep``, we extend ``BaseCommerceCheckoutStep`` for its base functionality.
+```
 
 ### Annotate the Class for OSGi Registration
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-low-stock-activity.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-low-stock-activity.md
@@ -38,7 +38,9 @@ In this section, we will get an example low stock activity up and running on you
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-order-validator.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-order-validator.md
@@ -36,7 +36,9 @@ In this section, we will get an example order validator up and running on your i
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-product-content-renderer.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-custom-product-content-renderer.md
@@ -38,7 +38,9 @@ In this section, we will get an example product content renderer up and running 
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-payment-method.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-payment-method.md
@@ -38,7 +38,9 @@ In this section, we will get an example payment method up and running on your in
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-shipping-engine.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-shipping-engine.md
@@ -40,7 +40,9 @@ In this section, we will get an example shipping engine up and running on your i
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-tax-engine.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-a-new-tax-engine.md
@@ -38,7 +38,9 @@ In this section, we will get an example tax engine up and running on your instan
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/developer-guide/tutorials/implementing-an-exchange-rate-provider.md
+++ b/docs/commerce/2.x/en/developer-guide/tutorials/implementing-an-exchange-rate-provider.md
@@ -44,7 +44,9 @@ In this section, we will get an example exchange rate provider up and running on
     ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
     ```
 
-    >**Note:** This command is the same as copying the deployed jars to /opt/liferay/osgi/modules on the Docker container.
+    ```note::
+       This command is the same as copying the deployed jars to ``/opt/liferay/osgi/modules`` on the Docker container.
+    ```
 
 1. Confirm the deployment in the Docker container console.
 

--- a/docs/commerce/2.x/en/orders-and-fulfillment/order-workflows/approving-or-rejecting-orders-in-order-workflows.md
+++ b/docs/commerce/2.x/en/orders-and-fulfillment/order-workflows/approving-or-rejecting-orders-in-order-workflows.md
@@ -18,7 +18,9 @@ Once the buyer has submitted his cart for pre-approval, or placed an order for s
 
    ![Review](./approving-or-rejecting-orders-in-order-workflows/images/03.png)
 
-    > **Note:** Alternatively, click _Assign to..._ and select another user to review the Commerce Order.
+    ```note::
+       Alternatively, click `Assign to...` and select another user to review the Commerce Order.
+    ```
 
 1. Add a comment (optionally) and click *Done*.
 

--- a/docs/commerce/2.x/en/starting-a-store/introduction-to-the-admin-account.md
+++ b/docs/commerce/2.x/en/starting-a-store/introduction-to-the-admin-account.md
@@ -34,7 +34,9 @@ The Admin user is created by default in any new installation of Liferay Commerce
 
     ![Setting a Password](./introduction-to-the-admin-account/images/04.png "Setting a Password")
 
-    > **Note:** This screen is where the _Password Reminder Question_ may also be updated.
+    ```note::
+       This screen is where the `Password Reminder Question` may also be updated.
+    ```
 
 ### Signing Out
 

--- a/docs/dxp-cloud/latest/en/build-and-deploy/understanding-deployment-types.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/understanding-deployment-types.md
@@ -58,7 +58,9 @@ By default, the services in DXP Cloud are pre-configured in order to fit a major
 }
 ```
 
-**Note:** the deployment type of the services in DXP Cloud must only be changed with caution, as it may result in data loss or impacted performance.
+```note::
+   The deployment type of the services in DXP Cloud must only be changed with caution, as it may result in data loss or impacted performance.
+```
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
@@ -10,8 +10,9 @@ cannot. Eventually, the domain will be reachable from any device and return the
 standard `default backend - 404` error from the Ingress Load Balancer. Now 
 you're ready for the next step. 
 
-> **Note:** You can find the dedicated environment IP on a service's Custom 
-> Domains or the Network page. 
+```note::
+   You can find the dedicated environment IP on a service's Custom Domains or the Network page.
+```
 
 ![Figure 1: This example uses Cloudflare as a domain name registrar to create DNS records.](./custom-domains/images/01.png)
 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/using-sso-with-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/security/using-sso-with-dxp-cloud.md
@@ -64,7 +64,9 @@ To log into DXP Cloud using SSO:
 1. Enter the **Company Name** in the _Organization ID_ field.
 1. Click _Continue_.
 
-    > **Note:** If you have already authenticated on your organization's SSO, you may not need to proceed through the following steps.
+    ```note::
+       If you have already authenticated on your organization's SSO, you may not need to proceed through the following steps.
+    ```
 
 1. Enter the **Email Address** in the _Email Address_ field. This must be the same email address stored in the company's database or directory service (such as an LDAP or ADFS).
 1. Enter the **Password** in the _Password_ field. This must be the same password associated with the email address stored in the company's database or directory service.

--- a/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
@@ -4,7 +4,9 @@ DXP Cloud uses [Jenkins](https://jenkins.io/) to power its continuous integratio
 
 By default, this automated build will compile code and can be configured to execute tests. DXP Cloud will build your services and show their status on your environment's Builds page. If the tests fail, you can check the Jenkins dashboard and logs at `https://ci-companyname-infra.lfr.cloud`.
 
-> **Note:** Continuous integration only works if you deploy from GitHub, GitLab, or Bitbucket, not the CLI.
+```note::
+   Continuous integration only works if you deploy from GitHub, GitLab, or Bitbucket, not the CLI.
+```
 
 ## Using the Default Jenkinsfile
 

--- a/docs/dxp-cloud/latest/en/reference/defining-environment-variables.md
+++ b/docs/dxp-cloud/latest/en/reference/defining-environment-variables.md
@@ -4,7 +4,9 @@ Environment variables are a set of dynamic placeholders that can affect the way 
 
 There are two ways to define environment variables: via the DXP Cloud Management Console or configuring the `LCP.json` file for each service.
 
-> **Note:** DXP Cloud will always apply the most recent changes to settings. If the latest changes are made in the LCP.json file, upon restart, the environment variables will be reflected in the web console. However, if the environment variables are changed in the web console, the container will be restarted with those new configurations.
+```note::
+   DXP Cloud will always apply the most recent changes to settings. If the latest changes are made in the LCP.json file, upon restart, the environment variables will be reflected in the web console. However, if the environment variables are changed in the web console, the container will be restarted with those new configurations.
+```
 
 ## Defining Environment Variables via the DXP Cloud Management Console
 

--- a/docs/dxp-cloud/latest/en/reference/support-access.md
+++ b/docs/dxp-cloud/latest/en/reference/support-access.md
@@ -6,7 +6,9 @@ can enable and disable Support Access per environment. For example, an
 administrator can enable Support Access on the development environment but 
 disable it on the production environment. 
 
-> **Note:** Support access is enabled by default in each environment. 
+```note::
+   Support access is enabled by default in each environment. 
+```
 
 When Support Access is enabled, Liferay Support engineers have read access 
 to the following information: 
@@ -18,9 +20,9 @@ to the following information:
 * Team members and their associated roles
 * Members' activities
 
-> **Note:** Only the project administrator can configure Support Access. Support 
-> Access **does not** allow Liferay Support engineers to deploy assets or 
-> perform write actions in your project. 
+```note::
+   Only the project administrator can configure Support Access. Support Access **does not** allow Liferay Support engineers to deploy assets or perform write actions in your project. 
+```
 
 ## Changing the Support Access Setting
 

--- a/docs/dxp-cloud/latest/en/reference/tracking-dxp-cloud-status-and-getting-help.md
+++ b/docs/dxp-cloud/latest/en/reference/tracking-dxp-cloud-status-and-getting-help.md
@@ -7,7 +7,9 @@ ticketing support on
 and 
 [phone support](https://help.liferay.com/hc/en-us/articles/360017784212).
 
-> **Note:** Details are subject to your legal agreement with Liferay. 
+```note::
+   Details are subject to your legal agreement with Liferay. 
+```
 
 For more detailed information about legal agreements and services, see 
 [liferay.com/legal](https://www.liferay.com/legal). 

--- a/docs/dxp-cloud/latest/en/troubleshooting/configuring-cross-region-disaster-recovery.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/configuring-cross-region-disaster-recovery.md
@@ -58,7 +58,9 @@ Follow these steps to restore the latest stable backup of Production to the DR e
 1. In the DR environment, click the *Backups* tab.
 1. Click the tab corresponding to the Production environment.
 
-    > Note: The Backup History lists the backups in two tabs: one for the DR environment and one for the Production environment.
+    ```note::
+       The Backup History lists the backups in two tabs: one for the DR environment and one for the Production environment.
+    ```
 
 1. Click the *Actions* button (![Actions](./disaster-recovery/images/02.png)), for the latest stable backup in the Production environment,  then select *Restore*.
 
@@ -100,7 +102,9 @@ During the incident, the DR environment functions as the Production environment 
 1. In the DR environment, click *Backups* in the menu on the left.
 1. Click the tab corresponding to the DR environment.
 
-    > **Note:** The Backup History lists the backups in two tabs: one for the DR environment and one for the Production environment.
+    ```note::
+       The Backup History lists the backups in two tabs: one for the DR environment and one for the Production environment.
+    ```
 
 1. For the most recent backup (the one you just created), click the *Actions* button (![Actions](./disaster-recovery/images/02.png)) then select *Restore*.
 1. Select the Production environment and click *Deploy Build*.

--- a/docs/dxp-cloud/latest/en/troubleshooting/log-management.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/log-management.md
@@ -14,7 +14,9 @@ the toolbar. To download the logs, click *Download Logs*.
 
 ## Accessing Logs from the Terminal
 
-> **Note:** To access logs via the terminal, you must be an administrator or developer. 
+```note::
+   To access logs via the terminal, you must be an administrator or developer. 
+```
 
 Run this command to access logs from your terminal: 
 

--- a/docs/dxp-cloud/latest/en/troubleshooting/shell-access.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/shell-access.md
@@ -7,7 +7,9 @@ For example, you can use the shell to look for side effects not easily spotted
 in the logs. You can also call functions for data population or report 
 generation that are meant to run only once. 
 
-| **Note:** The backup and database services do not provide shell access. 
+```note::
+   The backup and database services do not provide shell access. 
+```
 
 ## Accessing the Shell via the Web Console
 

--- a/docs/dxp/7.x/en/collaboration-and-social/message-boards/user-guide/creating-message-boards-threads.md
+++ b/docs/dxp/7.x/en/collaboration-and-social/message-boards/user-guide/creating-message-boards-threads.md
@@ -12,7 +12,9 @@ To create a new thread:
 1. Enter a title in the **Subject** field.
 1. Create your thread's content in the **Body** field.
 
-   > **Note:** This field uses the same editor as the Blogs app, except that it uses BBCode instead of HTML. For further instructions, see the documentation on [using the editor](https://help.liferay.com/hc/articles/360018173051-Using-the-Blog-Entry-Editor-).
+    ```note::
+      This field uses the same editor as the Blogs app, except that it uses BBCode instead of HTML. For further instructions, see the documentation on [using the editor](https://help.liferay.com/hc/articles/360018173051-Using-the-Blog-Entry-Editor-).
+    ```
 
     ![Figure 1. Creating the first post](./creating-message-boards-threads/images/01.png)
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-jboss-eap.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/installing-liferay/installing-liferay-on-an-application-server/installing-on-jboss-eap.md
@@ -198,13 +198,15 @@ Make the following edits as applicable to the respective operating system:
     JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Djboss.as.management.blocking.timeout=480 -Duser.timezone=GMT -Xms2560m -Xmx2560m -XX:MaxMetaspaceSize=512m"
     ```
 
-On JDK 11, add this JVM argument to display four-digit years.
+    On JDK 11, add this JVM argument to display four-digit years.
 
-```bash
--Djava.locale.providers=JRE,COMPAT,CLDR
-```
+    ```bash
+    -Djava.locale.providers=JRE,COMPAT,CLDR
+    ```
 
-**Note:** If using the IBM JDK with the JBoss server, complete these additional steps:
+    ```note::
+       If using the IBM JDK with the JBoss server, complete these additional steps:
+    ```
 
 1. Navigate to the `$JBOSS_HOME/modules/com/liferay/portal/main/module.xml` file and insert the following dependency within the `<dependencies>` element:
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/configuring-sso/authenticating-with-saml/saml-authentication-process-overview.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/configuring-sso/authenticating-with-saml/saml-authentication-process-overview.md
@@ -30,7 +30,9 @@ Upon successful authentication, the IdP constructs a SAML Response. It includes 
 
 The IdP sends the response to the Assertion Consumer Service URL. The request contains two parameters: `SAMLResponse` and `RelayState`.
 
-**Note:** The method for sending the SAML response (for example, HTTP-POST) and the Assertion Consumer Service URL are usually imported as part of the SAML metadata XML provided by the SP. In @product@, you import the SP's metadata in the SAML Adapter's Service Provider Connections tab.
+```note::
+   The method for sending the SAML response (for example, HTTP-POST) and the Assertion Consumer Service URL are usually imported as part of the SAML metadata XML provided by the SP. In @product@, you import the SP's metadata in the SAML Adapter's Service Provider Connections tab.
+```
 
 ### The SP Processes the SSO Response
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/configuring-sso/authenticating-with-saml/saml-configuration-reference.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/securing-liferay/configuring-sso/authenticating-with-saml/saml-configuration-reference.md
@@ -97,6 +97,8 @@ For example, if you're stuck connecting to a legacy IdP that only supports `SHA1
 
 Notice that in the configuration above, the `<md:Extensions>` block has only one signing algorithm: `SHA1`.
 
-> **Note:** Since the default configuration falls back to `SHA1`, you shouldn't need to do this unless your legacy system can't negotiate via the fallback mechanism. Also note that if you blacklisted `SHA1`, this won't work. Due to [vulnerabilities in `SHA1`](https://en.wikipedia.org/wiki/SHA-1), it's best to avoid using it altogether if possible.
+```note::
+   Since the default configuration falls back to `SHA1`, you shouldn't need to do this unless your legacy system can't negotiate via the fallback mechanism. Also note that if you blacklisted `SHA1`, this won't work. Due to `vulnerabilities in SHA1 <https://en.wikipedia.org/wiki/SHA-1>`__, it's best to avoid using it altogether if possible.
+```
 
 If you've changed your metadata configuration, you can go back to the default configuration if you saved it before making the change. If you didn't, you can provide a URL instead of an uploaded XML file to one of your peers' metadata configurations. -->

--- a/docs/dxp/7.x/en/users-and-permissions/devops/connecting-to-a-user-directory/configuring-user-import-and-export.md
+++ b/docs/dxp/7.x/en/users-and-permissions/devops/connecting-to-a-user-directory/configuring-user-import-and-export.md
@@ -76,6 +76,8 @@ This section contains settings for exporting Liferay user data to LDAP.
 
 When you've set all your options and tested your connection, click *Save*.
 
-**Note:** If a user changes a value like a password in Liferay, that change is passed to the LDAP server, provided Liferay has enough schema access to make the change.
+```note::
+   If a user changes a value like a password in Liferay, that change is passed to the LDAP server, provided Liferay has enough schema access to make the change.
+```
 
 Now you know how to connect an LDAP server to Liferay and how to configure user import behavior, export behavior, and other LDAP settings. There are other configurable options; [Configuring LDAP](./ldap-configuration-reference.md) describes those.

--- a/docs/dxp/7.x/en/users-and-permissions/users/adding-and-managing-users.md
+++ b/docs/dxp/7.x/en/users-and-permissions/users/adding-and-managing-users.md
@@ -12,7 +12,7 @@ Core user management activities include adding, editing, and deleting users. The
 1. Fill out the Add User form and click *Save*. At a minimum, provide a Screen Name, First Name, Last Name, and Email Address for the User.
 
     ```note::
-        **Note:** Screen names and email addresses are not interchangeable. A screen name cannot contain an `@` symbol because it is used in the URL to a User's private page.
+        Screen names and email addresses are not interchangeable. A screen name cannot contain an `@` symbol because it is used in the URL to a User's private page.
 
         The Add User functionality is split over several independent forms. Save the first form to create the User, and then you'll see a success message saying `Success. Your request completed successfully.`
     ```


### PR DESCRIPTION
This converts the bulk of all "Note:" notations into actual note admonitions throughout the docs. (As I mentioned earlier, there are a few cases where they were left as-is, if they are formatted in a way that an admonition won't work)