### PR TITLE
[DXP Cloud] Sweeping updates for project version 4

### DIFF
--- a/docs/dxp-cloud/latest/en/build-and-deploy/configuring-persistent-file-storage-volumes.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/configuring-persistent-file-storage-volumes.md
@@ -3,7 +3,9 @@
 Administrators can configure the volumes for their services in DXP Cloud depending on their deployment type (`Deployment` or `StatefulSet`). Volumes can be stored either with persistent shared storage (NFS) or with dedicated storage (SSD), depending on the deployment type. This article documents how to configure volumes via a service's `LCP.json` file. See [Understanding Deployment Types](./understanding-deployment-types.md) for more information on deplyoment types.
 
 1. Choose the folders that contain the data to be persisted (for example `/liferay/opt/data`).
-1. Navigate to the `LCP.json` file in the repository for the specific environment (for example, `lcp/liferay`).
+
+1. Navigate to the `LCP.json` file in the repository for the specific environment (for example, `liferay/`).
+
 1. Add the `volumes` configuration to the `LCP.json` file. This configuration must contain a key for each volume. For example, the following configuration contains a `data` key for `/liferay/opt/data`:
 
 ```json
@@ -17,13 +19,18 @@ Administrators can configure the volumes for their services in DXP Cloud dependi
 }
 ```
 
+```note::
+   If you are still using version 3.x.x services, then the ``LCP.json`` file for the ``liferay`` service is instead located in the ``lcp/liferay/`` directory.
+```
+
 ## Sharing Volumes Between Different Services
 
 Volumes are shared between all instances within a single service, but only volumes in `Deployment` type services may be shared with other services in the same environment using NFS. Volumes shared in this way are persisted even if the services are deleted, because they will be stored in NFS.
 
 To share a volume:
 
-1. Navigate to the `LCP.json` file in the Github repository for the service (`[ProjectID]/lcp/liferay/LCP.json`).
+1. Navigate to the `LCP.json` file in the Github repository for the service (`[ProjectID]/liferay/LCP.json`).
+
 1. Enter the following:
      * service's ID
      * location (absolute path) of the content to be shared

--- a/docs/dxp-cloud/latest/en/build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md
@@ -16,28 +16,29 @@ The repository provides the following:
 * Shared version control for configuration and customizations of DXP Cloud services. 
 * Single source of truth for DXP Cloud project deployments. 
 
-With the exception of the `common` folder, changes added to a given service's environment folder (e.g., `dev`, `uat`, `prd`) are only propagated when deploying to the corresponding environment. Changes added to `common` are always deployed regardless of the target deployment environment. See [Deployment](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#deployment-customization-patching-and-licensing) for more information.
+With the exception of the `common/` directory, changes added to an environment-specific folder (e.g., `dev`, `uat`, `prod`) will _only_ be propagated when deploying to the corresponding environment. Changes added to a `common/` directory will _always_ be deployed, regardless of the target deployment environment. This applies to all subfolders within the `configs/` directory, for all services. See [Deployment](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md#deployment-customization-patching-and-licensing) for more information.
 
 ### Code Additions
 
-The source for new code additions must be added to folders at the root of the
-repository: 
+The source for new code additions must be added to folders in the repository's `liferay/` directory: 
 
 * The `modules` folder for new modules
 * The `themes` folder for custom themes
 * The `wars` folder for exploded WARs 
 
-When the build is deployed, code changes in any of these locations are 
-automatically compiled and added to the Liferay DXP service. 
+When the build is deployed, code changes in any of these locations are automatically compiled and added to the Liferay DXP service.
+
+```note::
+   If you are still using version 3.x.x services, then these folders are instead located at the root of the repository.
+```
 
 ### Compiled Additions
 
-You can add compiled files (e.g., pre-built JARs or LPKGs) to a service's 
-`deploy` folder. When the build is deployed to an environment, these files are 
-copied to the corresponding folder within `$LIFERAY_HOME` (depending on the file 
-type). For example, adding a JAR file
-to `lcp/liferay/deploy/common/` will result in the file being copied to
-`$LIFERAY_HOME/osgi/modules/` for any environment the build is deployed to. 
+You can add compiled files (e.g., pre-built JARs or LPKGs) to a `liferay/configs/{ENV}/deploy/` folder. When the build is deployed to an environment, these files are copied to the corresponding folder within `$LIFERAY_HOME` (depending on the file type). For example, adding a JAR file to `liferay/configs/common/deploy/` will result in the file being copied to `$LIFERAY_HOME/osgi/modules/` for any environment the build is deployed to. 
+
+```note::
+   If you are still using version 3.x.x services, then these additions are instead added to the appropriate ``lcp/liferay/deploy/{ENV}`` folder.
+```
 
 ## Build and Test
 

--- a/docs/dxp-cloud/latest/en/build-and-deploy/walking-through-the-deployment-life-cycle.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/walking-through-the-deployment-life-cycle.md
@@ -9,7 +9,7 @@ This article will walk you through the steps to deploy a sample module similarly
 
 ## Prerequisites
 
-In order to get started, we will need the following:
+In order to get started, you will need the following:
 
 * A sample module
 * A configured DXP Cloud Git repository
@@ -26,14 +26,18 @@ Develop or use an existing module to deploy in this tutorial. This tutorial will
 
 ## Add the Sample to the Repository
 
-Begin the deployment life cycle by adding your sample module into the Git repository. Add the JAR to the appropriate `deploy` folder within `lcp/liferay`. For this tutorial, choose the folder for a development environment (e.g., `dev`):
+Begin the deployment life cycle by adding your sample module into the Git repository. Add the JAR to the appropriate `deploy` folder within `liferay/configs/{ENV}/deploy/`. For this tutorial, choose the folder for a development environment (e.g., `dev`):
 
 ```bash
-cp path-to-module/my-module my-repository-path/lcp/liferay/deploy/dev
+cp path-to-module/my-module my-repository-path/liferay/configs/dev/deploy
 ```
 
 ```note::
    This tutorial will assume your development environment is named ``dev``, by default. If your development environment is named differently, substitute ``dev`` with the correct name.
+```
+
+```note::
+   If you are still using version 3.x.x services, then the appropriate ``deploy/`` folder instead is in ``lcp/liferay/``. The environment-specific folder is also inside of ``deploy/``, so the path to use in the repository in this case is ``lcp/liferay/deploy/dev``. See `DXP Cloud Project Changes in Version 4 <#project-version-3-differences>`__ for more information on the differences in the directory structure.
 ```
 
 ## Deploy the Sample to the Development Environment
@@ -84,23 +88,9 @@ Click "Deploy Build to..." for any successful build to deploy to the environment
 
 ![Choosing an environment for deployment](./walking-through-the-deployment-life-cycle/images/04.png)
 
-### Deploy Using the CLI
+### Preparing LCP.json Files in Project Version 3
 
-Developers may use the DXP Cloud CLI tool to directly deploy to services if desired.
-
-First, ensure that you have the DXP Cloud CLI installed:
-
-```bash
-lcp version
-```
-
-```bash
-Liferay Cloud Platform CLI version 2.1.2 linux/amd64
-Build commit: 59e244b342d7b119f8e77eb94c6486f8049ca2b3
-Build time: Wed Jul 10 01:59:00 UTC 2019
-```
-
-If not, see the [Command Line Tool](../reference/command-line-tool.md) article for more information about installation and usage.
+If you are still using version 3.x.x services in your project, then you must first update the `LCP.json` files in your project to deploy using the CLI tool. Otherwise, skip to [the next section](#deploy-using-the-cli) to proceed.
 
 Open the `gradle.properties` at the root of your repository, and find properties for the Docker image versions for each of your services, like the following:
 
@@ -125,17 +115,39 @@ For example, use the value from the `liferay.workspace.lcp.search.image` propert
 "image": "@liferay.workspace.lcp.search.image@",
 ```
 
-To begin deploying the module, first navigate with your command prompt to the `lcp` directory. This is necessary to allow the CLI to traverse this directory for your changes.
+```important::
+   In project version 3, you must also navigate to the `lcp` directory in your repository before running the tool, so that it can traverse the directory and find your services' `LCP.json` files.
+```
+
+### Deploy Using the CLI
+
+Developers may use the DXP Cloud CLI tool to directly deploy to services if desired.
+
+First, ensure that you have the DXP Cloud CLI installed:
 
 ```bash
-cd lcp
+lcp version
 ```
+
+```bash
+Liferay Cloud Platform CLI version 2.1.2 linux/amd64
+Build commit: 59e244b342d7b119f8e77eb94c6486f8049ca2b3
+Build time: Wed Jul 10 01:59:00 UTC 2019
+```
+
+If not, see the [Command Line Tool](../reference/command-line-tool.md) article for more information about installation and usage.
+
+To begin deploying the module, run the `lcp deploy` command within your repository:
 
 ```bash
 lcp deploy --project=<project-name> --environment=dev
 ```
 
 ![Deploying through the CLI](./walking-through-the-deployment-life-cycle/images/05.png)
+
+```tip::
+   You can omit the ``--project`` and ``--environment`` parameters from the command usage, as well. Without these parameters, the tool will instead prompt you to enter them while it is running.
+```
 
 Once the command finishes running, the module will be copied to the chosen environment. The affected services will need some time to restart and apply the new module to the Docker images.
 
@@ -165,9 +177,11 @@ When the `webserver` service is ready to use, navigate to it, and then click on 
    You can also go directly to ``https://webserver-<project-name>-<environment>.lfr.cloud/`` to get to the same location.
 ```
 
-You can use the Gogo shell to easily confirm whether your module was deployed. Navigate to the Control Panel → Configuration → Gogo Shell. From here, use this command to check whether the module has been deployed:
+You can use the Gogo shell to easily confirm whether your module was deployed. Navigate to the _Control Panel_ → _Configuration_ → _Gogo Shell_. From here, enter this command to check whether the module has been deployed:
 
-`lb | grep "my.module.name"`
+```
+lb | grep "my.module.name"`
+```
 
 ![Verifying module deployment](./walking-through-the-deployment-life-cycle/images/08.png)
 

--- a/docs/dxp-cloud/latest/en/getting-started/configuring-your-bitbucket-repository.md
+++ b/docs/dxp-cloud/latest/en/getting-started/configuring-your-bitbucket-repository.md
@@ -9,7 +9,9 @@ The provisioned repository will be on GitHub, but you can transfer it to a BitBu
 
 ## Preparing the Jenkins service
 
-Before you start, check the `LCP.json` for your `ci` service, and ensure you're running the following Jenkins service or higher:
+If you are using version 4.x.x services in your DXP Cloud instance already, then your Jenkins service is already compatible with Bitbucket. See [Upgrading Your DXP Cloud Stack](../reference/upgrading-your-dxp-cloud-stack.md) for more information on upgrading.
+
+If you are still using version 3.x.x services, then check the `LCP.json` for your `ci` service, and ensure you're running the following Jenkins service or higher:
 
 ```
 liferaycloud/jenkins:2.222.1-3.2.0

--- a/docs/dxp-cloud/latest/en/getting-started/configuring-your-gitlab-repository.md
+++ b/docs/dxp-cloud/latest/en/getting-started/configuring-your-gitlab-repository.md
@@ -9,7 +9,9 @@ The provisioned repository will be on GitHub, but you can transfer it to a GitLa
 
 ## Preparing the Jenkins Service
 
-Before you start, check the `LCP.json` for your `ci` service, and ensure you're running the following Jenkins service or higher:
+If you are using version 4.x.x services in your DXP Cloud instance already, then your Jenkins service is already compatible with GitLab. See [Upgrading Your DXP Cloud Stack](../reference/upgrading-your-dxp-cloud-stack.md) for more information on upgrading.
+
+If you are still using version 3.x.x services, then check the `LCP.json` for your `ci` service, and ensure you're running the following Jenkins service or higher:
 
 ```
 liferaycloud/jenkins:2.222.1-3.2.0

--- a/docs/dxp-cloud/latest/en/platform-services/backup-and-restore.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-and-restore.md
@@ -46,18 +46,10 @@ The following formats are supported for SQL scripts:
 
 Note that scripts are run in alphanumerical order when they are executed. SQL scripts must also reference the exact database to run on (for example, with `USE lportal;` or `lportal.User_`).
 
-Place the scripts into the subfolder for the appropriate environment within `lcp/backup/script/`:
+Place the scripts into the appropriate, environment-specific `backup/configs/{ENV}/scripts/` folder.
 
-```
-lcp
-└── backup
-    ├── LCP.json
-    └── script
-        ├── common
-        ├── dev
-        ├── local
-        ├── prd
-        └── uat
+```note::
+   If you are still using version 3.x.x services, then SQL scripts instead belong in the appropriate ``lcp/backup/script/{ENV}/`` folder.
 ```
 
 ### Performing the Data Restore

--- a/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
@@ -12,22 +12,27 @@ By default, this automated build will compile code and can be configured to exec
 
 In the past, we used to give customers an entire `Jenkinsfile` for them to customize. The problem with this approach is that bug fixes, security fixes, and improvements had to be manually applied, line by line.
 
-Starting with version `liferaycloud/jenkins:2.222.1-3.2.0`, we are introducing the concept of Default Jenkinsfile. We encapsulated all the logic that was previously stored on the Jenkinsfile and moved it to a Jenkins plugin.
+Starting with CI service version `liferaycloud/jenkins:2.222.1-3.2.0`, we are introducing the concept of a default Jenkinsfile. The default Jenkinsfile is always available for use for projects using version 4.x.x services. This encapsulates all the logic that was previously stored on the Jenkinsfile and moves it to a Jenkins plugin.
 
 This means that all bug fixes, security fixes, and improvements can be applied by us, without any requiring any user action.
 
-Apart from that, we're providing a powerful set of extension points for you to customize every step of the pipeline.
+Apart from that, a powerful set of extension points are now provided for you to customize every step of the pipeline.
 
 ### Enable the Default Jenkinsfile
 
-1. Update to version `liferaycloud/jenkins:2.222.1-3.2.0`
+If your project is already updated to version 4.x.x, then these steps are already complete. Otherwise, enable the default Jenkinsfile by performing the following steps:
+
+1. Update your CI service to version `liferaycloud/jenkins:2.222.1-3.2.0`
+
 1. Delete the `Jenkinsfile` located on the root folder
+
 1. Add the following environment variable: `LCP_CI_USE_DEFAULT_JENKINSFILE: true`
+
 1. Deploy Jenkins service
 
 ## Extending the Default Jenkinsfile
 
-To extend the Default Jenkinsfile, you can add the following files to the `lcp/ci` folder:
+To extend the Default Jenkinsfile, you can add the following files to the `ci` folder in your project repository:
 
 - `Jenkinsfile-before-all`
 - `Jenkinsfile-before-cloud-build`
@@ -37,25 +42,36 @@ To extend the Default Jenkinsfile, you can add the following files to the `lcp/c
 
 Here is a basic overview of the steps in the CI build process:
 
-1. Load `lcp/ci/Jenkinsfile-before-all`, if it exists.
+1. Load `ci/Jenkinsfile-before-all`, if it exists.
+
 1. Build the Liferay Workspace.
-1. Load `lcp/ci/Jenkinsfile-before-cloud-build`, if it exists.
+
+1. Load `ci/Jenkinsfile-before-cloud-build`, if it exists.
+
 1. Create the DXP Cloud build that you see in console.
-1. Load `lcp/ci/Jenkinsfile-before-cloud-deploy`, if it exists.
+
+1. Load `ci/Jenkinsfile-before-cloud-deploy`, if it exists.
+
 1. Optionally deploy the build to an environment in the cloud, depending on if
    the current branch has been specified as the deploy branch. This is
    configured through the `LCP_CI_DEPLOY_BRANCH` environment variable. The
    `LCP_CI_DEPLOY_TARGET` environment variable specifies which environment to deploy
    to.
-1. Load `lcp/ci/Jenkinsfile-after-all`, if it exists. This will run when all steps are done.
-1. Load `lcp/ci/Jenkinsfile-post-always`, if it exists. This will run both when the
+
+1. Load `ci/Jenkinsfile-after-all`, if it exists. This will run when all steps are done.
+
+1. Load `ci/Jenkinsfile-post-always`, if it exists. This will run both when the
    build fails and when it succeeds.
+
+```note::
+   If you are still using version 3.x.x services, then these extensions to the Jenkinsfile are located in the ``lcp/ci/`` folder instead.
+```
 
 To see how they are used in the default pipeline, simply monitor the Jenkins service startup logs. The full default Jenkinsfile is printed out in the startup logs.
 
 ## Reusing Code Between Different Extension Points
 
-You will likely want a way to share code between these extension points. One basic way is to load a groovy script. For example, you could create a groovy file called `lcp/ci/util.groovy` with these contents:
+You will likely want a way to share code between these extension points. One basic way is to load a groovy script. For example, you could create a groovy file in the `ci/` folder called `util.groovy` with these contents:
 
 ```
 def sendSlackMessage(message) {
@@ -65,12 +81,16 @@ def sendSlackMessage(message) {
 return this
 ```
 
-Then you could insert the following in `lcp/ci/Jenkinsfile-before-cloud-build`:
+Then you could insert the following in `ci/Jenkinsfile-before-cloud-build`:
 
 ```
 def util = load("ci/util.groovy")
 
 util.sendSlackMessage("About to create DXP Cloud build...")
+```
+
+```note::
+   If you are still using version 3.x.x services, then these files instead belong in the ``lcp/ci/`` directory in the repository.
 ```
 
 ## Environment Variables Reference
@@ -92,3 +112,5 @@ Name                                          | Default Value   | Description |
 * [Logging into your DXP Cloud Services](../getting-started/logging-into-your-dxp-cloud-services.md)
 * [Configuring Your GitLab Repository](../getting-started/configuring-your-gitlab-repository.md)
 * [Configuring Your Bitbucket Repository](../getting-started/configuring-your-bitbucket-repository.md)
+* [DXP Cloud Project Changes in Version 4](../reference/dxp-cloud-project-changes-in-version-4.md)
+<!-- While Version 3 is still supported, because of the fact a large part of this article hinges on the project version, this link may be helpful. This link should likely be removed once version 3 is no longer supported. -->

--- a/docs/dxp-cloud/latest/en/platform-services/search-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/search-service.md
@@ -10,15 +10,21 @@ services in your application, not with the outside internet.
 
 Although DXP Cloud's services are fine-tuned to work well by default, you may 
 need to configure Elasticsearch further. To do so, you can include any YML file 
-inside the `config` folder. When you deploy your changes, the file is 
+inside the appropriate `configs/{ENV}/config/` folder. When you deploy your changes, the file is 
 automatically injected into your service and overwrites the default 
 configuration. Here's an example folder structure of such a file inside the 
-`config` folder: 
+correct folder: 
 
     search
-    ├── config
-    │ └── elasticsearch.yml
+    ├── configs
+    │   └── common
+    │       └── config
+    │           └── elasticsearch.yml
     └── LCP.json
+
+```note::
+   If you are still using version 3.x.x services, then these configuration files instead belong in the appropriate ``lcp/search/config/{ENV}/`` folder.
+```
 
 ## Scripts
 
@@ -26,24 +32,34 @@ You can use scripts for more extensive customizations. However, use caution when
 doing so. This is the most powerful way to customize the search service and can 
 cause undesired side effects. 
 
-Any `.sh` files found in the `script` folder are run prior to starting your 
+Any `.sh` files found in a `scripts/{ENV}/scripts/` folder are run prior to starting your 
 service. For example, to include a script that removes all log files, you could 
 place it in this directory structure: 
 
     search
-    ├── script
-    │ └── remove-log-files.sh
+    ├── configs
+    │   └── common
+    │       └── scripts
+    │           └── elasticsearch.yml
     └── LCP.json
+
+```note::
+   If you are still using version 3.x.x services, then these scripts instead belong in the appropriate ``lcp/search/script/{ENV}/`` folder.
+```
 
 ## Deploying a License to the Search Service
 
 To deploy a license to the search service, you must create the path 
-`lcp/search/license/common` and put your license file there. 
+`search/configs/{ENV}/license/` and put your license file there.
+
+```note::
+   If you are still using version 3.x.x services, then instead put your license file in a ``lcp/search/license/common/` folder.
+```
 
 ## Environment Variables Reference
 
 All environment variables and other forms of configuration for Elastisearch are in the [official Elastisearch documentation](https://www.elastic.co/guide/index.html).
-You can set such configurations and environment variables in the `config` directory and `LCP.json`, respectively. Examples include:
+You can set such configurations and environment variables in the `configs/{ENV}/config/` directory and `LCP.json`, respectively. Examples include:
 
 | Name | Value | Description |
 | --- | --- | --- |

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -10,22 +10,30 @@ high-performance web server.
 
 Although DXP Cloud's services are fine-tuned to work well by default, you may 
 need to configure Nginx further. To do this, you can include any CONF file 
-inside the `config` folder. When you deploy your changes, the file is 
+inside the `configs/{ENV}/conf.d/` folder. When you deploy your changes, the file is 
 automatically injected into your service and overwrites the default 
 configuration. Here's an example folder structure of such a file inside the 
-`config` folder: 
+appropriate directory: 
 
-    loadbalancer
-    ├── config
-    │ └── nginx.conf
+    webserver
+    ├── configs
+    │   └── common
+    │       └── conf.d
+    │           └── nginx.conf
     └── LCP.json
+
+Files in `/webserver/configs/{ENV}/` will be copied as overrides into /etc/nginx/ in the webserver container in DXP Cloud. Files in `/webserver/configs/{ENV}/public/` will be copied as overrides into var/www/html/.
+
+```note::
+   If you are still using version 3.x.x services, then Nginx configurations instead belong in the appropriate ``lcp/webserver/config/{ENV}/`` directory.
+```
 
 ## Environment Variables
 
 This service has no environment variables specific to DXP Cloud. All environment 
 variables and other forms of configuration for Nginx are in the 
 [official Nginx documentation](https://docs.nginx.com/). 
-You can set such configurations and environment variables in the `config` 
+You can set such configurations and environment variables in the `configs/{ENV}/` 
 directory and `LCP.json`, respectively. 
 
 ## Scripts
@@ -34,11 +42,17 @@ You can use scripts for more extensive customizations. However, use caution when
 doing so. This is the most powerful way to customize the web server service and 
 can cause undesired side effects. 
 
-Any `.sh` files found in the `script` folder are run prior to starting your 
+Any `.sh` files found in the `configs/{ENV}/scripts/` folder are run prior to starting your 
 service. For example, to include a script that removes all log files, you could 
 place it in this directory structure: 
 
-    loadbalancer
-    ├── script
-    │ └── remove-log-files.sh
+    webserver
+    ├── configs
+    │   └── common
+    │       └── scripts
+    │           └── remove-log-files.sh
     └── LCP.json
+
+```note::
+   If you are still using version 3.x.x services, then webserver scripts instead belong in the appropriate ``lcp/webserver/script/{ENV}/`` directory.
+```

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
@@ -11,6 +11,7 @@ Several changes are made between version 3.x and 4.x of the DXP Cloud stack, inc
 * [CI Service Changes](#ci-service-changes)
 * [Webserver Service Changes](#webserver-service-changes)
 * [Backup Service Changes](#backup-service-changes)
+* [Known Limitations](#known-limitations)
 
 ## Changes to Docker Image Definitions
 
@@ -126,6 +127,10 @@ All configurations within the `backup` service now belong in an environment-spec
 | **File** | **Location in 3.x** | **Location in 4.x** |
 | --- | --- | --- |
 | Custom SQL scripts | lcp/backup/script/{ENV}/ | backup/configs/{ENV}/scripts/ |
+
+## Known Limitations
+
+The new stack does not contain a docker-compose file to spin up a local environment. However, we're planning a much better local development experience in the future.
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
@@ -130,7 +130,9 @@ All configurations within the `backup` service now belong in an environment-spec
 
 ## Known Limitations
 
-The new stack does not contain a docker-compose file to spin up a local environment. However, we're planning a much better local development experience in the future.
+The new stack does not contain a docker-compose file to spin up a local environment. Because of this, a DXP bundle is needed for local testing.
+
+You can test changes in a local environment, and then migrate them to DXP Cloud. See [Migrating from an On-Premises DXP Installation](../using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md) for more help.
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/configuring-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/configuring-the-liferay-dxp-service.md
@@ -1,26 +1,33 @@
 # Configuring the Liferay DXP Service
 
-There are several methods available to configure Liferay DXP: through the in [DXP System Settings](https://learn.liferay.com/dxp/7.x/en/system-administration/system-settings/system-settings.html) and through the use of [config](https://learn.liferay.com/dxp/7.x/en/system-administration/system-settings/using-configuration-files.html) and [property files](https://learn.liferay.com/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.html).  DXP property and configuration files for your Liferay DXP instance in DXP Cloud are deployed by being placed inside of one of the `config` folders in the Liferay DXP service directory in your repository.
+There are several methods available to configure Liferay DXP: through the in [DXP System Settings](https://learn.liferay.com/dxp/7.x/en/system-administration/system-settings/system-settings.html) and through the use of [config](https://learn.liferay.com/dxp/7.x/en/system-administration/system-settings/using-configuration-files.html) and [property files](https://learn.liferay.com/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.html).  DXP property and configuration files for your Liferay DXP instance in DXP Cloud are deployed by being placed inside of one of the `configs/` folders in the Liferay DXP service directory in your repository.
 
 ```
-lcp
-└── liferay
-  ├── LCP.json
-  └── config
-    ├── common
-    ├── dev
-    ├── local
-    ├── prd
-    └── uat
+liferay
+├── configs
+│   ├── common
+│   ├── dev
+│   ├── local
+│   ├── prd
+│   └── uat
+└── LCP.json
 ```
 
-With the exception of the `common/` directory, changes added to a given service's environment folder (e.g., `dev`, `uat`, `prod`) will _only_ be propagated when deploying to the corresponding environment. Changes added to the `common/` directory will _always_ be deployed, regardless of the target deployment environment. This applies to the `config`, `deploy`, `license`, and `script` directories within `lcp/liferay/`.
+With the exception of the `common/` directory, changes added to an environment-specific folder (e.g., `dev`, `uat`, `prod`) will _only_ be propagated when deploying to the corresponding environment. Changes added to a `common/` directory will _always_ be deployed, regardless of the target deployment environment. This applies to all subfolders within the `configs/` directory, for all services.
+
+```note::
+   If you are still using version 3.x.x services, then these configuration files instead belong in the appropriate ``lcp/liferay/config/{ENV}/`` folder.
+```
 
 ## Portal Properties
 
 [Portal properties](https://learn.liferay.com/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.html) are files of the form `portal-*.properties` that are used to configure your Liferay DXP environment.
 
-In an on-site Liferay DXP instance, these files belong inside of `$LIFERAY_HOME`. When using Liferay DXP Cloud, place these files into the appropriate `config` folder(s) for them to be copied into `$LIFERAY_HOME` for the Liferay DXP instance on deployment.
+In an on-site Liferay DXP instance, these files belong inside of `$LIFERAY_HOME`. When using Liferay DXP Cloud, place these files into the appropriate `configs/{ENV}/` folder(s) for them to be copied into `$LIFERAY_HOME` for the Liferay DXP instance on deployment.
+
+```note::
+   If you are still using version 3.x.x services, then these configuration files instead belong in the appropriate ``lcp/liferay/config/{ENV}/`` folder.
+```
 
 These are the types of portal properties files you may use in one of the `config` folders:
 
@@ -40,7 +47,11 @@ These are the types of portal properties files you may use in one of the `config
 
 OSGi configurations (`.cfg` or `.config` files) are used to configure OSGi components in Liferay DXP.
 
-These configuration files belong in the `/osgi/configs` folder inside of `$LIFERAY_HOME`. When using Liferay DXP Cloud, place these files into the appropriate `config` folder(s) for them to be copied into `/osgi/configs` for the Liferay DXP instance on deployment.
+These configuration files belong in the `osgi/configs/` folder inside of `$LIFERAY_HOME`. When using Liferay DXP Cloud, place these files into the appropriate `configs/{ENV}/osgi/` folder(s) for them to be copied into `/osgi/configs` for the Liferay DXP instance on deployment.
+
+```note::
+   If you are still using version 3.x.x services, then OSGi configuration files instead belong in the appropriate ``config/{ENV/`` folder within the Liferay service directory.
+```
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -16,93 +16,119 @@ The Liferay DXP service in DXP Cloud can be used in many of the same ways as an 
 
 ## Choosing a Version
 
-The version of Liferay DXP that you are using is configured within the `gradle.properties` file at the root of your Git repository.
+The version of Liferay DXP that you are using is configured within the `LCP.json` file within the `liferay` folder of your Git repository.
 
-```properties
-liferay.workspace.lcp.liferay.image=liferaycloud/liferay-dxp:7.2.10-ga1-3.0.10
+```
+"image": "liferaycloud/liferay-dxp:7.2-4.0.1"
+```
+
+```note::
+   If your DXP Cloud stack is not yet updated to 4.x.x, then by default, this version is instead located within a ``gradle.properties`` file at the root of the repository (using the ``liferay.workspace.lcp.liferay.image`` property).
 ```
 
 This version includes the specific service pack and fix pack that your Liferay DXP instance will be based on.
 
 You can check the [Services Changelog](https://help.liferay.com/hc/en-us/sections/360006251311-Services-Changelog) for DXP Cloud to see a reference for each new release. Each new Service update includes Docker images that you can use for your instance.
 
-Use the new version from the release notes to update the `liferay.workspace.lcp.liferay.image` property value. The new Docker image will be used when your instance starts up or the next time you deploy the Liferay service from your repository. You can also use the Docker images for new releases to upgrade the properties for your other services.
-
-```note::
-   If any ``LCP.json`` files in your repository directly reference the Docker image for a version of Liferay, then these will need to be updated as well when upgrading to a new Docker image.
-```
+Use the new version from the release notes to update the Docker image value. The new Docker image will be used when your instance starts up or the next time you deploy the Liferay service from your repository. You can also use the Docker images for new releases to upgrade the properties for your other services.
 
 ## Deployment (Customization, Patching, and Licensing)
 
 Deploying custom additions to Liferay DXP involves adding the new module, license, or hotfix to the appropriate locations in the Git repository.
 
-With the exception of the `common/` directory, changes added to a given service's environment folder (e.g., `dev`, `uat`, `prod`) will _only_ be propagated when deploying to the corresponding environment. Changes added to the `common/` directory will _always_ be deployed, regardless of the target deployment environment. This applies to the `config`, `deploy`, `hotfix`, `license`, and `script` directories within `lcp/liferay/`.
+With the exception of the `common/` directory, changes added to an environment-specific folder (e.g., `dev`, `uat`, `prod`) will _only_ be propagated when deploying to the corresponding environment. Changes added to a `common/` directory will _always_ be deployed, regardless of the target deployment environment. This applies to all subfolders within the `configs/` directory, for all services.
 
-See [Overview of the Deployment Workflow](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md) for more information on how the deployment workflow. For a tutorial on deploying to DXP Cloud see, [Walking Through the Deployment Life Cycle](../build-and-deploy/walking-through-the-deployment-life-cycle.md).
+See [Overview of the Deployment Workflow](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md) for more information on how the deployment workflow. For a tutorial on deploying to DXP Cloud, see [Walking Through the Deployment Life Cycle](../build-and-deploy/walking-through-the-deployment-life-cycle.md).
 
 ### Themes, Portlets, and OSGi Modules
 
-To install themes, portlets, or OSGi modules, include a WAR or JAR file in one of the folders in `/deploy` in your Liferay DXP service directory.
+To install themes, portlets, or OSGi modules, include a WAR or JAR file into a `configs/{ENV}/deploy/` folder in your Liferay DXP service directory.
 
-For example, to deploy a custom JAR file to your development environment (using the `/dev` folder), your Liferay DXP service directory could look like this:
+For example, to deploy a custom JAR file to your development environment (using the `dev/` environment folder), your Liferay DXP service directory could look like this:
 
 ```
-lcp
-  └── liferay
-    ├── deploy
-    │   └── dev
-    │       └── com.liferay.apio.samples.portlet-1.0.0.jar
-    └── LCP.json
+liferay
+  ├── LCP.json
+  └── configs
+      └── dev
+          ├── deploy
+          │   └── com.liferay.apio.samples.portlet-1.0.0.jar
+          ├── osgi
+          ├── patching
+          ├── scripts
+          └── portal-ext.properties
+```
+
+```note::
+   If you are still using version 3.x.x services in your repository, then themes, portlets, and OSGi modules instead belong in the appropriate ``lcp/liferay/deploy/{ENV} folder.
 ```
 
 ### Source Code
 
-The source code for new additions can also be included in a CI build. When the build starts, it will automatically compile the source code. Then, behind the scenes, the build will copy the results to the correct `deploy` folder.
+The source code for new additions can also be included in a CI build. When the build starts, it will automatically compile the source code. 
 
 A CI build will compile source code within these folders:
 
-* The `modules` folder for new modules
-* The `themes` folder for custom themes
-* The `wars` folder for exploded WARs
+* The `liferay/modules` folder for new modules
+* The `liferay/themes` folder for custom themes
+* The `liferay/wars` folder for exploded WARs
 
 ```note::
    Source code will only be included in a deployment if it is deployed from a build in CI.
 ```
 
+```note::
+   If you are still using version 3.x.x services, then these subfolders are located at the root of the repository instead of in the ``liferay/`` directory.
+```
+
 ### Hotfixes
 
-To apply hotfixes, add the hotfix ZIP file to one of the folders in `hotfix/` within the Liferay DXP service directory. When you deploy this change, the hotfix is applied to the Liferay DXP instance.
+To apply hotfixes, add the hotfix ZIP file to a `configs/{ENV}/patching/` folder within the Liferay DXP service directory. When you deploy this change, the hotfix is applied to the Liferay DXP instance.
 
 For example, you can deploy a hotfix to your development environment with a structure like the following:
 
 ```
-lcp
-  └── liferay
-    ├── hotfix
-    │   └── dev
-    │       └── liferay-hotfix-2-7110.zip
-    └── LCP.json
+liferay
+  ├── LCP.json
+  └── configs
+      └── dev
+          ├── deploy
+          ├── osgi
+          ├── patching
+          │   └── liferay-hotfix-2-7110.zip
+          └── scripts
 ```
 
-Note that hotfixes will each need to be re-applied each time the server starts up. For this reason, updating to the latest Fix Pack or Service pack of the Liferay DXP Docker image in your `gradle.properties` file is better than adding many hotfixes into this folder for the long term; you can update the Docker version by replacing the `liferay.workspace.lcp.liferay.image` property in this file. The `gradle.properties` file can be found at the root of the repository.
+Note that hotfixes will each need to be re-applied each time the server starts up. For this reason, updating to the latest Fix Pack or Service pack of the Liferay DXP Docker image in your `LCP.json` file is better than adding many hotfixes into this folder for the long term; you can update the Docker version by replacing the `image` environment variable in this file (in the `liferay/` directory.
+
+```note::
+   If you are still using version 3.x.x services, then hotfixes are instead added into the ``lcp/liferay/hotfix/`` folder. The Docker image version in this case is instead defined with the ``liferay.workspace.lcp.liferay.image`` property, in your repository's ``gradle.properties`` file.
+```
 
 ### Licenses
 
-You can add your own license by putting it into one of the folders in `license/` within the Liferay DXP service directory.
+You can add your own license by putting it into a `configs/{ENV}/deploy/` folder within the Liferay DXP service directory.
 
 For example, you can add licenses to your development environment with a structure like this in your Liferay DXP service directory:
 
 ```
-lcp
-  └── liferay
-    ├── license
-    │   └── dev
-    │       └── license.xml
-    │       └── license.aatf
-    └── LCP.json
+liferay
+  ├── LCP.json
+  └── configs
+      └── dev
+          ├── deploy
+          │   ├── license.xml
+          │   └── license.aatf
+          ├── osgi
+          ├── patching
+          └── scripts
 ```
 
 Behind the scenes, XML licenses are copied to `$LIFERAY_HOME/deploy`, and AATF licenses are copied to `$LIFERAY_HOME/data`.
+
+```note::
+   If you are still using version 3.x.x services, then licenses instead belong in the ``lcp/liferay/license/{ENV}/ folder in your repository.
+```
 
 ## Configuration
 
@@ -122,17 +148,24 @@ Clustering Liferay DXP in DXP Cloud is a very simplified process compared to doi
 
 ## Running Scripts
 
-Any `.sh` files found in the `script` folder are automatically run prior to starting the service. Scripts may be used for more extensive customizations. However, use caution when doing so. This is the most powerful way to customize Liferay DXP and it can cause undesired side effects.
+Any `.sh` files found in the `configs/{ENV}/scripts` folder are automatically run prior to starting the service. Scripts may be used for more extensive customizations. However, use caution when doing so. This is the most powerful way to customize Liferay DXP and it can cause undesired side effects.
 
 For example, to include a script that removes all log files, place it in the following directory structure within the project's Git repository:
 
 ```
-lcp
-└──liferay
-    ├── script
-    │   └── dev
-    │       └── remove-log-files.sh
-    └── LCP.json
+liferay
+├── LCP.json
+└── configs
+    └── dev
+        ├── deploy
+        ├── osgi
+        ├── patching
+        └── scripts
+            └── remove-log-files.sh
+```
+
+```note::
+   If you are still using version 3.x.x services, then scripts instead belong in the ``lcp/liferay/script/`` folder in the repository.
 ```
 
 ## Environment Variables Reference

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -15,10 +15,14 @@ This step should be done when the database is not being updated in order to prev
 
 ### Export a Database Dump
 
-Begin by exporting the data to a database dump. The export from MySQL can be accomplished using the following command:
+Begin by exporting the data to a database dump. The export from MySQL can be accomplished using the following commands:
 
 ```bash
 mysqldump -uroot -ppassword --databases --add-drop-database lportal | gzip -c | cat > database.gz
+```
+
+```bash
+tar zcvf database.tgz database.gz
 ```
 
 ```important::
@@ -51,7 +55,7 @@ Run this command to invoke the API and upload the zipped files:
 curl -X POST \
   https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
-  -F 'database=@/my-folder/database.gz' \
+  -F 'database=@/my-folder/database.tgz' \
   -F 'volume=@/my-folder/volume.tgz' \
   -u user@domain.com:password
 ```
@@ -69,18 +73,21 @@ Once these are uploaded, the backup service will initialize a DXP Cloud backup.
 Portal properties and OSGi configurations can be copied over to DXP Cloud by putting them into the appropriate folder per environment (e.g., `dev`, `uat`, or `prd`, or `common` to apply to all) inside of `lcp/liferay/config/`.
 
 ```
-    |-- lcp
-        |-- liferay
-            |-- LCP.json
-            |-- config
-                |-- common
-                |-- dev
-                |-- local
-                |-- prd
-                |-- uat
+liferay
+  ├── configs
+  |   ├── common
+  |   ├── dev
+  |   ├── local
+  |   ├── prd
+  |   └── uat
+  └── LCP.json
 ```
 
 Any portal properties of the form `portal-*.properties` placed in one of the appropriate folders will be automatically copied over to the `$LIFERAY_HOME` within the Liferay DXP service for the applicable environment(s). OSGi properties (.cfg or .config files) will be copied over to the `osgi/configs` folder within the Liferay DXP service for the applicable environment(s).
+
+```note::
+   If you are still using version 3.x services, then these configuration files instead belong in the appropriate ``lcp/liferay/config/{ENV}/`` folder in your repository.
+```
 
 ## Add Service Configurations
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/setting-up-clustering-in-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/setting-up-clustering-in-dxp-cloud.md
@@ -17,13 +17,13 @@ Start from the desired environment in the DXP Cloud Management Console. Then, un
 
 ## Set the Clustering Scale
 
-The number of nodes for your clustering environment is determined by the `scale` property within the Liferay service's `LCP.json` file (in `lcp/liferay/`). If you are deploying your Liferay service for the first time, or if the `scale` property has not yet been set in the `LCP.json` file, then you must first set the value to `1` and then [deploy the service](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md#deploy).
+The number of nodes for your clustering environment is determined by the `scale` property within the Liferay service's `LCP.json` file (in the `liferay/` folder). If you are deploying your Liferay service for the first time, or if the `scale` property has not yet been set in the `LCP.json` file, then you must first set the value to `1` and then [deploy the service](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md#deploy).
 
 ```json
 {
   "kind": "Deployment",
   "id": "liferay",
-  "image": "@liferay.workspace.lcp.liferay.image@",
+  "image": "liferaycloud/liferay-dxp:7.2-4.0.1",
   "memory": 8192,
   "cpu": 8,
   "scale": 1,


### PR DESCRIPTION
This contains a variety of changes to account for changes between the DXP Cloud service stack from 3 to 4. The bulk of changes are simple updates to the directories, with a bit of rephrasing here and there.

As we discussed in a previous call, the preferred way to handle it where possible is to, where there are differences, have the information for version 4 first, then have a note right under it for version 3. I wound up using our `note::` admonitions for these... although I think the notes do create a fair bit of bulk in the articles, especially in cases where there are already other notes present. (My only other thought would have been to use the "quote" syntax like we used to for notes to try and reduce that, but I know we want to avoid using these for general notes, so maybe that's still not preferable)

Some of the more noteworthy updates:
- In Walking through the Deployment Life Cycle, a whole step of the process became unnecessary in version 4 (copying image names into `LCP.json` for each service). I tried several ways of neatly addressing this, but ended up just refactoring that step into a more clear step on its own, and specifying that it can be skipped for version 4. (The downside is that it is not exactly matching the ideal of, everything in the main flow of the article being primarily for version 4)
- The CI overview article similarly includes a whole set of steps that apply only to version 3.
- In the "DXP Cloud Project Changes in Version 4" article, the note as to the known limitation with Docker compose is included. I did some rephrasing though, and also added a bit to redirect readers to using a local bundle for local testing, as a workaround. See: https://github.com/liferay/liferay-learn/pull/118   (/cc @zenorocha)

Please let me know what you think of how I handled it here, and if you see any issues with this. Thank you!