### PR TITLE
fixed article name in landing card

### DIFF
--- a/docs/dxp-cloud/latest/en/landing.html
+++ b/docs/dxp-cloud/latest/en/landing.html
@@ -76,7 +76,7 @@
 							url: 'manage-and-optimize/real-time-alerts.html'
 						},
 						{
-							name: 'Team Collaboration & Access Control',
+							name: 'Environment Teams & Roles',
 							url: 'manage-and-optimize/environment-teams-and-roles.html'
 						},
 					]


### PR DESCRIPTION
Just noticed this error. Though I had changed the article link, I hadnt changed the article's display name in the landing card.