### PR TITLE
[DXP Cloud] Document how to install hotfixes without committing to repository

### DIFF
--- a/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
@@ -98,6 +98,7 @@ The following environment variables are only used in the default Jenkinsfile. To
 Name                                          | Default Value   | Description |
 --------------------------------------------- | --------------- | ----------- |
 `LCP_CI_USE_DEFAULT_JENKINSFILE`      | `false`         | Option to enable of disable the Default Jenkinsfile |
+`LCP_CI_LIFERAY_DXP_HOTFIXES_{ENV}`   |                 | Comma-delimited list of hotfixes for CI to apply automatically when deploying the Liferay service. Replace `{ENV}` with the environment name (in all-caps), or `COMMON`. |
 `LCP_CI_BUILD_TIMEOUT_MINUTES`        | `30`            | Set a timeout period for the Pipeline run, after which Jenkins should abort the Pipeline  |
 `LCP_CI_PRESERVE_STASHES_BUILD_COUNT` | `20`            | Preserve stashes from completed builds, for use with stage restarting |
 `LCP_CI_BUILD_NUM_TO_KEEP`            | `10`            | Number of builds that will be stored |

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-project-changes-in-version-4.md
@@ -46,6 +46,8 @@ The following table summarizes the new organization of your `liferay` service co
    Files within the ``configs/{ENV}/`` directory will be copied as overrides into the ``LIFERAY_HOME`` directory in the Liferay container in DXP Cloud.
 ```
 
+Instead of directly committing hotfixes to the repository, a new CI service environment variable is now available to automatically add when deploying the Liferay service. See [Installing Hotfixes with an Environment Variable](#installing-hotfixes-with-an-environment-variable) for more information.
+
 ### Custom Script Execution
 
 Scripts placed in `liferay/configs/{ENV}/scripts/` will now be run as the `liferay` user, rather than as a root user. If a script must be run as root, then the script must be added to the `Jenkinsfile` instead.
@@ -79,6 +81,19 @@ If you would like to install additional Elasticsearch plugins beyond the ones ou
 A default `Jenkinsfile` is no longer required in the repository, as a default pipeline is now defined. Any `Jenkinsfile` is now defined in the `ci` folder, rather than the root of the repository.
 
 Multiple `Jenkinsfile` extension points are now available in the `ci` folder to define procedures at different stages of creating a build. <!-- TODO: Add reference to Jenkinsfile-specific article -->
+
+### Installing Hotfixes with an Environment Variable
+
+Instead of directly committing large hotfixes to your Git repository, a new environment variable has been added that allows you to install hotfixes through the CI build process. Add a comma-delimited list of hotfixes to the `LCP_CI_LIFERAY_DXP_HOTFIXES_{ENV}` environment variable (either through the `Environment Variables` tab in the DXP Cloud console, or in the `ci` service's `LCP.json` file) for the CI service to automatically apply them during the build process.
+
+See the following example of defining hotfixes through in the `LCP.json` file:
+
+```
+"env": {
+    "LCP_CI_LIFERAY_DXP_HOTFIXES_COMMON": "liferay-hotfix-10-7210,liferay-hotfix-17-7210",
+    "LCP_CI_LIFERAY_DXP_HOTFIXES_DEV": "liferay-hotfix-15-7210,liferay-hotfix-33-7210",
+}
+```
 
 ## Webserver Service Changes
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -105,6 +105,25 @@ Note that hotfixes will each need to be re-applied each time the server starts u
    If you are using version 3.x.x services, then hotfixes are instead added into the ``lcp/liferay/hotfix/`` folder. The Docker image version in this case is instead defined with the ``liferay.workspace.lcp.liferay.image`` property, in your repository's ``gradle.properties`` file. See `Understanding Service Stack Versions <../reference/understanding-service-stack-versions.md>`__ for more information on checking the version.
 ```
 
+#### Patching via Environment Variable
+
+You can also install hotfixes as part of the CI build process instead of directly committing them to your Git repository. This approach is ideal for large hotfixes so you can avoid keeping large files in your repository.
+
+Add a comma-delimited list of hotfixes to the `LCP_CI_LIFERAY_DXP_HOTFIXES_{ENV}` environment variable (either through the `Environment Variables` tab in the DXP Cloud console, or in the `ci` service's `LCP.json` file) for the CI service to automatically apply them during the build process.
+
+See the following example of defining hotfixes through in the `LCP.json` file:
+
+```
+"env": {
+    "LCP_CI_LIFERAY_DXP_HOTFIXES_COMMON": "liferay-hotfix-10-7210,liferay-hotfix-17-7210",
+    "LCP_CI_LIFERAY_DXP_HOTFIXES_DEV": "liferay-hotfix-15-7210,liferay-hotfix-33-7210",
+}
+```
+
+```note::
+   This environment variable is only available if you have upgraded to at least version 4.x.x services. See `Understanding Service Stack Versions <../reference/understanding-service-stack-versions.md>`__ for more information on checking the version.
+```
+
 ### Licenses
 
 You can add your own license by putting it into a `configs/{ENV}/deploy/` folder within the Liferay DXP service directory.

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -16,19 +16,23 @@ The Liferay DXP service in DXP Cloud can be used in many of the same ways as an 
 
 ## Choosing a Version
 
-The version of Liferay DXP that you are using is configured within the `LCP.json` file within the `liferay` folder of your Git repository.
+The major version of Liferay DXP that you are using is configured within the `LCP.json` file within the `liferay/` folder of your Git repository. Set the major version as the `image` variable using a Docker image name within the `LCP.json` file:
 
 ```
 "image": "liferaycloud/liferay-dxp:7.2-4.0.1"
 ```
 
-```note::
-   If your DXP Cloud stack is not yet updated to 4.x.x, then by default, this version is instead located within a ``gradle.properties`` file at the root of the repository (using the ``liferay.workspace.lcp.liferay.image`` property). See `Understanding Service Stack Versions <../reference/understanding-service-stack-versions.md>`__ for more information on checking the version.
+Define the specific service pack and fix pack through the `gradle.properties` file within the same `liferay/` folder. The `liferay.workspace.docker.image.liferay` property defines another Docker image name with this specific fix pack level that is used for the actual deployment:
+
+```properties
+liferay.workspace.docker.image.liferay=liferay/dxp:7.2.10-sp2-202005120922
 ```
 
-This version includes the specific service pack and fix pack that your Liferay DXP instance will be based on.
+```note::
+   If your DXP Cloud stack is not yet updated to 4.x.x, then by default, this version is instead located within a ``gradle.properties`` file at the root of the repository. In this case, define the version with the ``liferay.workspace.lcp.liferay.image`` property (which does not need to be defined separately from the major version). See `Understanding Service Stack Versions <../reference/understanding-service-stack-versions.md>`__ for more information on checking the version.
+```
 
-You can check the [Services Changelog](https://help.liferay.com/hc/en-us/sections/360006251311-Services-Changelog) for DXP Cloud to see a reference for each new release. Each new Service update includes Docker images that you can use for your instance.
+You can check the [Services Changelog](https://help.liferay.com/hc/en-us/sections/360006251311-Services-Changelog) for DXP Cloud to see a reference for each new release. Each new Service update includes Docker images that you can use for your instance. You can also directly check the [DXP tags on Docker Hub](https://hub.docker.com/r/liferay/dxp/tags?page=1) to find the Docker image names to use.
 
 Use the new version from the release notes to update the Docker image value. The new Docker image will be used when your instance starts up or the next time you deploy the Liferay service from your repository. You can also use the Docker images for new releases to upgrade the properties for your other services.
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8144

Version 4.x.x adds an environment variable that allows you to install hotfixes through the CI build process, rather than having to commit them to the repository (ideal for large hotfixes). This adds documentation explaining this in the following locations:

- **CI Service Article ("Continuous Integration")**: adding it to the documented table of environment variables
- **DXP Cloud Project Changes in Version 4**: adding it to the list of new features
- **Introduction to the Liferay DXP Service**: adding it as an option within the explanation of patching

Additionally, this adds missing explanation as to the fact that the `LCP.json` is meant moreso for defining the major version of DXP, and not the fix packs -- and the `gradle.properties` is more meant for the specific fix pack version.

Let me know if there are any questions or concerns. Thank you!