### PR TITLE
Fix links to gogo-shell-commands.md

### DIFF
--- a/docs/dxp/7.x/en/liferay-internals/fundamentals/using-the-gogo-shell/command-line-gogo-shell.md
+++ b/docs/dxp/7.x/en/liferay-internals/fundamentals/using-the-gogo-shell/command-line-gogo-shell.md
@@ -54,4 +54,4 @@ You can execute commands in a `telnet` session:
 
 ## Conclusion
 
-Now that you know how to run Gogo shell from the command line, explore the available [Gogo shell commands](./gogo-shell-commands). If you need to use Gogo shell in a production environment, please see [Using the Gogo Shell](./using-the-gogo-shell.md).
+Now that you know how to run Gogo shell from the command line, explore the available [Gogo shell commands](./gogo-shell-commands.md). If you need to use Gogo shell in a production environment, please see [Using the Gogo Shell](./using-the-gogo-shell.md).

--- a/docs/dxp/7.x/en/liferay-internals/fundamentals/using-the-gogo-shell/using-the-gogo-shell.md
+++ b/docs/dxp/7.x/en/liferay-internals/fundamentals/using-the-gogo-shell/using-the-gogo-shell.md
@@ -37,4 +37,4 @@ The Control Panel is the safest, most secure way to access Gogo shell:
 
 ## Conclusion
 
-Now that you know how to run Gogo shell, explore the available [Gogo shell commands](./gogo-shell-commands). If you're working in a developer environment, consider Gogo shell from the command line. See [Command Line Gogo Shell](./command-line-gogo-shell.md) for more information.
+Now that you know how to run Gogo shell, explore the available [Gogo shell commands](./gogo-shell-commands.md). If you're working in a developer environment, consider Gogo shell from the command line. See [Command Line Gogo Shell](./command-line-gogo-shell.md) for more information.


### PR DESCRIPTION
My links were missing the `.md` part of the filename.