### PR TITLE
[COMMERCE] LRDOCS-8568 Fix compile error in Shipping Engine tutorial

### DIFF
--- a/docs/commerce/2.x/en/developer-guide/implementing-a-new-shipping-engine.md
+++ b/docs/commerce/2.x/en/developer-guide/implementing-a-new-shipping-engine.md
@@ -225,7 +225,7 @@ public List<CommerceShippingOption> getCommerceShippingOptions(
 
     try {
         commerceShippingOptions = _getCommerceShippingOptions(
-            commerceContext.getSiteGroupId(), commerceOrder, locale);
+            commerceOrder.getScopeGroupId(), commerceOrder, locale);
     }
     catch (PortalException pe) {
         if (_log.isDebugEnabled()) {

--- a/docs/commerce/2.x/en/developer-guide/implementing-a-new-shipping-engine/resources/liferay-j6x8.zip/j6x8-impl/src/main/java/com/acme/j6x8/internal/commerce/model/J6X8CommerceShippingEngine.java
+++ b/docs/commerce/2.x/en/developer-guide/implementing-a-new-shipping-engine/resources/liferay-j6x8.zip/j6x8-impl/src/main/java/com/acme/j6x8/internal/commerce/model/J6X8CommerceShippingEngine.java
@@ -60,7 +60,7 @@ public class J6X8CommerceShippingEngine implements CommerceShippingEngine {
 
 		try {
 			commerceShippingOptions = _getCommerceShippingOptions(
-				commerceContext.getSiteGroupId(), commerceOrder, locale);
+				commerceOrder.getScopeGroupId(), commerceOrder, locale);
 		}
 		catch (PortalException pe) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8568

Removal of API broke the tutorial code. Thankfully in this instance a simple substitution seems to be available to fix it.