### PR TITLE
[DXP Cloud] LRDOCS-7858 Correct detail about sharing between instances

### DIFF
--- a/docs/dxp-cloud/latest/en/build-and-deploy/configuring-persistent-file-storage-volumes.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/configuring-persistent-file-storage-volumes.md
@@ -25,7 +25,7 @@ Administrators can configure the volumes for their services in DXP Cloud dependi
 
 ## Sharing Volumes Between Different Services
 
-Volumes are shared between all instances within a single service, but only volumes in `Deployment` type services may be shared with other services in the same environment using NFS.
+Only volumes in `Deployment` type services may be shared with other services in the same environment using NFS. `StatefulSet` type services each have their own volumes which may not be shared.
 
 To share a volume:
 

--- a/docs/dxp-cloud/latest/en/build-and-deploy/understanding-deployment-types.md
+++ b/docs/dxp-cloud/latest/en/build-and-deploy/understanding-deployment-types.md
@@ -27,13 +27,13 @@ The following summarizes some distinguishing characteristics between the `Deploy
 
 In general, the `Deployment` type is more lightweight and allows for faster deployments, as well as shared volumes between services (for shared files, like the document library). The `StatefulSet` type is more costly for deployments and resource usage (including the total memory and CPUs allocated for your project), but persists data through deployments and gains improved file access performance by using a dedicated SSD.
 
-### Persisted Volumes (NFS) vs SSD Storage
+### Shared Volumes (NFS) vs SSD Storage
 
 The Network File System (NFS) is available to all `Deployment` type services. NFS will persist regardless of whether a service is re-deployed or even deleted.
 
 The volumes stored in NFS are also available to all `Deployment` type services. NFS is used out-of-the-box for the `Liferay` and `Backup` services to share access to the document library. See [Configuring Persistent File System Volumes](./configuring-persistent-file-storage-volumes.md) for more information on configuring volumes for NFS.
 
-`StatefulSet` type services instead have a dedicated SSD for all volume storage. The dedicated SSD available to `StatefulSet` type services is not accessible to other services. Volumes stored on the SSD also persist on re-deployment and after service deletion.
+`StatefulSet` type services instead have a dedicated SSD for all volume storage. The dedicated SSD available to `StatefulSet` type services is not accessible to other services. Volumes stored on the SSD also persist on re-deployment and after service deletion. In clustered `StatefulSet` services, each instance has a different volume.
 
 ## How DXP Cloud's Services are Configured
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-7858
And also: https://github.com/jrhoun/liferay-learn/pull/784

Correction (confirmed after personally testing) that instances of `StatefulSet` services do **not** share their volumes between them.