### PR TITLE
[DXP Cloud] LRDOCS-8511 Third-party references

### DIFF
--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -29,7 +29,7 @@ tar zcvf database.tgz database.gz
    The ``databases`` and ``add-drop-database`` options are necessary for backup restoration to work correctly.
 ```
 
-Database dumps imported into DXP Cloud must be in MySQL format for the database service to use it. If necessary, a tool like [DBeaver](http://dbeaver.io) can be used to convert other types of databases to MySQL for the import.
+Database dumps imported into DXP Cloud must be in MySQL format for the database service to use it.
 
 ### Zip Up the Document Library
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8511

Originally from @JamesAGarcia at: https://github.com/Alec-Shay/liferay-learn/pull/74

This removes DBeaver as a referenced third-party tool, as it may cause headaches for support if clients have issues with it. The ticket requests all third-party references removed, but we've both scanned over the site overall and haven't found any other references that seemed potentially problematic.