### PR TITLE
[DXP Cloud] LRDOCS-8201 Using shell for troubleshooting network connections

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/connecting-a-vpn-server-to-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/connecting-a-vpn-server-to-dxp-cloud.md
@@ -76,6 +76,10 @@ The VPN details page indicates whether or not the VPN is already connected in th
 
 The VPN attempts to connect after clicking the button. If the connection fails, then the failed attempt displays in the _Related Activities_ section of the details page.
 
+```tip::
+   You can manually test the connectivity of your services to an IP address through your VPN by using the service's `shell <../../troubleshooting/shell-access.md>`__ to run a command like the following: ``curl -v [address]``.
+```
+
 To disconnect the VPN, click _Disconnect_ from the top-right Actions menu. This takes you to the _Disconnect VPN_ page.
 
 ```warning::
@@ -84,7 +88,7 @@ To disconnect the VPN, click _Disconnect_ from the top-right Actions menu. This 
 
 ![The Disconnect VPN page asks you to confirm the impact of disconnecting before proceeding.](./connecting-a-vpn-server-to-dxp-cloud/images/07.png)
 
-Check the boxes confirming the impact of disconnecting the VPN, and then click _Disconnect VPN_ to immediately disconnect it. Once the VPN is disconnected, the configuration can be change again.
+Check the boxes confirming the impact of disconnecting the VPN, and then click _Disconnect VPN_ to immediately disconnect it. Once the VPN is disconnected, the configuration can be changed again.
 
 ### Editing the Configuration
 
@@ -98,3 +102,4 @@ To edit the configuration, go to the environment's details page, and then _Edit.
 
 * [VPN Integration Overview](./vpn-integration-overview.md)
 * [Configuring a VPN Server](./configuring-a-vpn-server.md)
+* [Shell Access](../../troubleshooting/shell-access.md)

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/private-network.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/private-network.md
@@ -19,7 +19,11 @@ variables:
 
 `external`: Whether your connection is available to external connections. The 
 default value `false` restricts the connection to internal DXP Cloud 
-connections. 
+connections.
+
+```tip::
+   If you expose the connection to external connections, then you may need to troubleshoot the connection using your service's shell. See `Shell Access <../../troubleshooting/shell-access.md>`__ for more information.
+```
 
 Here's an example configuration: 
 
@@ -54,3 +58,4 @@ Here's an example configuration:
 ## Additional Information
 
 * [Configuration via LCP JSON](../../reference/configuration-via-lcp-json.md)
+* [Shell Access](../../troubleshooting/shell-access.md)

--- a/docs/dxp-cloud/latest/en/troubleshooting/troubleshooting-tools-and-resources.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/troubleshooting-tools-and-resources.md
@@ -73,6 +73,14 @@ When troubleshooting issues, use the shell access tool to look inside your appli
 
 ![Figure 5: Use the shell access tool in the DXP Cloud console to see what's going on inside your application.](./troubleshooting-tools-and-resources/images/05.png)
 
+The shell is accessible in most services, including `liferay` and the `ci` services. It can be used to access the server's file system directly and run commands for troubleshooting purposes.
+
+For example, you can run the following command from the `ci` service's shell to test connection to an address or external server:
+
+```bash
+curl -v [address]
+```
+
 See [Shell Access](./shell-access.md) for more information.
 
 ## Self-Healing


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8201

This adds a tip in a few locations suggesting the use of a command from the shell to test a service's connection to an external IP.

Note that this does not include the also suggested change to "mention the Ingress load balancer IP." I double-checked on this and I'm not sure this actually would be a single address we could list, although I posed this as a question on the ticket just in case.