### PR TITLE
LRDOCS-7848 LRDOCS-7716 Tuning Liferay and the JVM Wordsmithed

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.md
@@ -150,7 +150,7 @@ mail.session.jndi.name=mail/SomeMailSession
 
 You can add a properties file for a specific environment, such as a development environment. Then you can use a single `portal-ext.properties` for common properties, and an environment-specific configuration for others.
 
-1. Create an arbitrary extension file (e.g., `portal-development.properties`) for your environment and add environment-specific properties to it:
+1. Create an arbitrary extension file (e.g., `portal-developer.properties`) for your environment and add environment-specific properties to it:
 
     ```properties
     mail.session.jndi.name=mail/DevMailSession
@@ -159,16 +159,16 @@ You can add a properties file for a specific environment, such as a development 
 1. Include the new extension file as a properties source by adding this `include-and-override` property to the top of your `portal-ext.properties` file:
 
     ```properties
-    include-and-override=portal-development.properties
+    include-and-override=portal-developer.properties
     ```
 
 Resulting properties source order:
 
 1. `portal-impl.jar/portal.properties`
 1. `[Liferay Home]/portal-ext.properties`
-1. `[Liferay Home]/portal-development.properties`
+1. `[Liferay Home]/portal-developer.properties`
 
-The last value defined for `mail.session.jndi.name` is in `[Liferay Home]/portal-development.properties`.
+The last value defined for `mail.session.jndi.name` is in `[Liferay Home]/portal-developer.properties`.
 
 Resulting configuration:
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
@@ -83,7 +83,7 @@ In Tomcat, the thread pools are configured in the `$CATALINA_HOME/conf/server.xm
 />
 ```
 
-If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, try `maxThreads=300`. Adjust connection pool settings and test your system to find settings that meet your needs.
+If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, set `maxThreads=300`. If you're testing an I/O-based load or you're concerned about I/O capacity, use more threads or switch to using a non-I/O blocking connector. Test your system and adjust connection pool settings to meet your needs.
 
 Additional tuning parameters around `Connector` are available, including the connector types, the connection timeouts, and TCP queue. Consult your application server's documentation for details.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
@@ -15,7 +15,7 @@ These features help during development but slow down performance. They're not in
 
 ### Portal Developer Properties
 
-Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
 
 ```properties 
 include-and-override=portal-developer.properties

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
@@ -15,7 +15,7 @@ These features help during development but slow down performance. They're not in
 
 ### Portal Developer Properties
 
-Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your `portal-ext.properties` file using this setting:
 
 ```properties 
 include-and-override=portal-developer.properties

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay.md
@@ -1,0 +1,119 @@
+# Tuning Liferay
+
+There are several ways to tune Liferay's performance. This involves configuring the Java Virtual Machine and frameworks that support the Liferay application, monitoring performance and resources, and adjusting settings to meet your needs. Here's an overview of the tuning topics.
+
+## Disable Developer Settings
+
+Here are some of the ways Liferay and its supporting frameworks facilitate development: 
+
+* Accommodate debuggers
+* Perform system checks
+* Upgrade data on startup automatically
+* Poll for code changes to apply automatically
+
+These features help during development but slow down performance. They're not intended for production environments and must therefore be disabled to optimize performance. Start with disabling all developer Portal Properties.
+
+### Portal Developer Properties
+
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+
+```properties 
+include-and-override=portal-developer.properties
+```
+
+If you included Liferay's `portal-developer.properties` file or included your own developer properties files (e.g., `[Liferay Home]/portal-developer.properties`), disable them by commenting them out in your `portal-ext.properties` file:
+
+```properties 
+#include-and-override=portal-developer.properties
+#include-and-override=${liferay.home}/portal-developer.properties
+```
+
+Similarly, if you enabled any developer properties individually, comment them out too.
+
+Next, disable developer settings in your JSP engine.
+
+### JSP Engine Settings
+
+Many application servers' JSP Engines are set for development by default. Deactivate these settings prior to entering production:
+
+**Development mode:** This makes the JSP container poll the file system for changes to JSP files. Since you don't change JSPs on-the-fly like this in production, turn off this mode.
+
+**Mapped File:** In development, it's typical to generate static content with one print statement versus one statement per line of JSP text. In production, opt for the latter.
+
+To disable development mode and the mapped file in Tomcat, for example, update the `$CATALINA_HOME/conf/web.xml` file's JSP servlet configuration to this:
+
+```xml
+<servlet>
+    <servlet-name>jsp</servlet-name>
+    <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>   
+    <init-param>
+        <param-name>development</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <init-param>
+        <param-name>mappedFile</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>3</load-on-startup>
+</servlet>
+```
+
+Development mode and the mapped file are disabled.
+
+## Thread Pool 
+
+Each request to the application server consumes a worker thread for the duration of the request. When no threads are available to process requests, the request is queued to wait for the next available worker thread. In a finely tuned system, the number of threads in the thread pool are balanced with the total number of concurrent requests. There should not be a significant amount of threads left idle to service requests.
+
+Use an initial thread pool setting of 50 threads and then monitor it within your application server's monitoring consoles. You may wish to use a higher number (e.g., 250) if your average page times are in the 2-3 second range. Too few threads in the thread pool might queue excessive requests; too many threads can cause excessive context switching.
+
+In Tomcat, the thread pools are configured in the `$CATALINA_HOME/conf/server.xml` file's `Connector` element. The [Apache Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/config/http.html) provides more details. Here's an example thread pool configuration:
+
+```xml
+<Connector
+    address="xxx.xxx.xxx.xxx"
+    connectionTimeout="600000"
+    maxConnections="16384"
+    maxKeepAliveRequests="-1"
+    maxThreads="75"
+    minSpareThreads="50"
+    port="8080"
+    redirectPort="8443"
+    socketBuffer="-1"
+    URIEncoding="UTF-8"
+/>
+```
+
+If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, try `maxThreads=300`. Adjust connection pool settings and test your system to find settings that meet your needs.
+
+Additional tuning parameters around `Connector` are available, including the connector types, the connection timeouts, and TCP queue. Consult your application server's documentation for details.
+
+## Database Connection Pool
+
+Database connection pools manage database connections for reuse, saving you from opening new connections with every new request. Liferay can use C3PO, DBCP, HikariCP, or Tomcat for connection pooling. The connection pool provider is set using the `jdbc.default.liferay.pool.provider` [Portal Property](../reference/portal-properties.md). HikariCP is the default.
+
+The database connection pool should be roughly 30-40% of the thread pool size. It provides a connection whenever Liferay needs to retrieve data from the database (e.g., user login). If the pool size is too small, requests queue in the server waiting for database connections. If the size is too large, however, idle database connections waste resources. As with thread pools, monitor these settings and adjust them based on your performance tests.
+
+In Tomcat, the connection pools are configured in the Resource elements in `$CATALINA_HOME/conf/Catalina/localhost/ROOT.xml`. Here's an example connection pool configuration:
+
+```xml
+<Resource
+    acquireIncrement="5"
+    auth="Container"
+    description="Liferay DB Connection"
+    driverClass="[place the driver class name here]"
+    factory="org.apache.naming.factory.BeanFactory"
+    jdbcUrl="[place the URL to your database here]"
+    maxPoolSize="75"
+    minPoolSize="10"
+    name="jdbc/LiferayPool"
+    password="[place your password here]"
+    type="com.mchange.v2.c3p0.ComboPooledDataSource"
+    user="[place your user name here]"
+/>
+```
+
+This configuration starts with 10 connections and increments by 5 as needed to a maximum of 75 connections in the pool.
+
+## Java Virtual Machine
+
+Your application server runs in a Java Virtual Machine (JVM). Memory management and garbage collection affect how fast Liferay responds to user requests. Please see [Tuning Your JVM](./tuning-your-jvm.md) for instructions next.

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
@@ -1,3 +1,103 @@
-# Tuning Your JVM 
+# Tuning Your JVM
 
-Coming soon!
+Java Virtual Machine (JVM) tuning primarily focuses on adjusting the garbage collector and the Java memory heap. We used Oracle's 1.8 JVM for the reference architecture. You may choose other supported JVM versions and implementations. Please consult the  [Liferay DXP Compatibility Matrix](https://web.liferay.com/group/customer/dxp/support/compatibility-matrix) for additional compatible JVMs.
+
+Here are the JVM tuning topics:
+
+* [Garbage Collector](#garbage-collector)
+* [Code Cache](#code-cache)
+* [Java Heap](#java-heap)
+* [JVM Advanced Options](#jvm-advanced-options)
+
+Garbage collection is first.
+
+## Garbage Collector
+
+Choosing the appropriate garbage collector (GC) helps improve the responsiveness of your Liferay DXP deployment. Use the concurrent low pause collectors:
+
+```bash
+-XX:+UseParNewGC -XX:ParallelGCThreads=16 -XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled -XX:+CMSCompactWhenClearAllSoftRefs
+-XX:CMSInitiatingOccupancyFraction=85 -XX:+CMSScavengeBeforeRemark
+```
+
+You may choose from other available GC algorithms, including parallel throughput collectors and G1 collectors. Start tuning using parallel collectors in the new generation and concurrent mark sweep (CMS) in the old generation.
+
+**Note:** the `ParallelGCThreads` value (e.g., `ParallelGCThreads=16`) varies  based on the type of CPUs available. Set the value according to CPU specification. On Linux machines, report the number of available CPUs by running `cat /proc/cpuinfo`.
+
+**Note:** There are additional "new" algorithms like G1, but Liferay Engineering's tests for G1 indicated that it does not improve performance. Since your application performance may vary, you should add G1 to your testing and tuning plans.
+
+## Code Cache
+
+Java's just-in-time (JIT) compiler generates native code to improve performance. The default size is `48m`. This may not be sufficient for larger applications. Too small a code cache reduces performance, as the JIT isn't able to optimize high frequency methods. For Liferay DXP,  start with `64m` for the initial code cache size.
+
+```bash
+-XX:InitialCodeCacheSize=64m -XX:ReservedCodeCacheSize=96m
+```
+
+Examine the efficacy of the parameter changes by adding the following logging parameters:
+
+```bash
+-XX:+PrintCodeCache -XX:+PrintCodeCacheOnCompilation
+```
+
+## Java Heap
+
+When most people think about tuning the Java memory heap, they think of setting the maximum and minimum memory of the heap. Unfortunately, most deployments require far more sophisticated heap tuning to obtain optimal performance, including tuning the young generation size, tenuring durations, survivor spaces, and many other JVM internals.
+
+For most systems, it's best to start with at least the following memory settings:
+
+```bash
+server -XX:NewSize=700m -XX:MaxNewSize=700m -Xms2560m -Xmx2560m -XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=512m -XX:SurvivorRatio=6 -XX:TargetSurvivorRatio=9 -XX:MaxTenuringThreshold=15
+```
+
+On systems that require large heap sizes (e.g., above 4GB), it may be beneficial to use large page sizes. You can activate large page sizes like this:
+
+```bash
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+```
+
+You may choose to specify different page sizes based on your application profile.
+
+**Note:** To use large pages in the JVM, you must configure your underlying operating system to activate them. In Linux, run `cat /proc/meminfo` and look at
+"huge page" items.
+
+```note::
+   **Caution:** Avoid allocating more than 32GB to your JVM heap. Your heap size should be commensurate with the speed and quantity of available CPU resources.
+```
+
+## JVM Advanced Options
+
+The following advanced JVM options were also applied in the Liferay benchmark environment:
+
+```bash
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+-XX:+UseCompressedOops -XX:+DisableExplicitGC -XX:-UseBiasedLocking
+-XX:+BindGCTaskThreadsToCPUs -XX:UseFastAccessorMethods
+```
+
+Please consult your JVM documentation for additional details on advanced JVM options.
+
+Combining the above recommendations together, makes this configuration:
+
+```bash
+server -XX:NewSize=1024m -XX:MaxNewSize=1024m -Xms4096m
+-Xmx4096m -XX:MetaspaceSize=512m -XX:MaxMetaspaceSize=512m
+-XX:SurvivorRatio=12 -XX:TargetSurvivorRatio=90
+-XX:MaxTenuringThreshold=15 -XX:+UseLargePages
+-XX:LargePageSizeInBytes=256m -XX:+UseParNewGC
+-XX:ParallelGCThreads=16 -XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled -XX:+CMSCompactWhenClearAllSoftRefs
+-XX:CMSInitiatingOccupancyFraction=85 -XX:+CMSScavengeBeforeRemark
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+-XX:+UseCompressedOops -XX:+DisableExplicitGC -XX:-UseBiasedLocking
+-XX:+BindGCTaskThreadsToCPUs -XX:+UseFastAccessorMethods
+-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=96m
+```
+
+```note::
+   **Caution:** The above JVM settings should formulate a starting point for your performance tuning. Every system's final parameters vary due to many factors, including number of current users and transaction speed.
+```
+
+Monitor the garbage collector statistics to ensure your environment has sufficient allocations for metaspace and also for the survivor spaces. Using the configuration above in the wrong environment could result in dangerous runtime scenarios like out of memory failures. Improperly tuned survivor spaces also lead to wasted heap space.

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
@@ -1,0 +1,3 @@
+# Tuning Your JVM 
+
+Coming soon!

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm.md
@@ -2,7 +2,7 @@
 
 Java Virtual Machine (JVM) tuning primarily focuses on adjusting Java heap and non-heap settings and configuring garbage collection. Finding settings that perform well for you depend on your system's load and your hardware. The settings discussed here can be used as a starting point for tuning your JVM. 
 
-We used Oracle's 1.8 JVM for the reference architecture. You may choose other supported JVM versions and implementations. Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for additional compatible JVMs.
+Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for compatible JVMs.
 
 ## Set Heap and Non-Heap Space
 
@@ -22,7 +22,7 @@ The JVM's memory comprises heap and non-heap spaces. The heap contains a space f
 | Memory Setting | Explanation |
 | :------ | :---------- |
 | `-Xms2560m` | Initial space for heap. |
-| `-Xmx2560m` | Maximim space for heap. |
+| `-Xmx2560m` | Maximum space for heap. |
 | `-XX:NewSize=1536m`| Initial new space. Setting the new size to half of the total heap typically provides better performance than using a smaller new size. |
 | `-XX:MaxNewSize=1536m` | Maximum new space. |
 | `-XX:MetaspaceSize=768m` | Initial space for static content. |
@@ -50,7 +50,7 @@ In the old generation space (in the heap), large garbage collections can cause n
 | :------ | :---------- |
 | `-XX:SurvivorRatio=16` | Makes the survivor space 1/16 of the new space (the initial new space is `1536m`). |
 | `-XX:TargetSurvivorRatio=50` | Instructs the JVM to use 50% of the survivor space after each Eden garbage collection. |
-| `-XX:MaxTenuringThreshold=15` | Keeps survivors to stay in the survivor space for up to 15 garbage collections before promotion to the old generation space. |
+| `-XX:MaxTenuringThreshold=15` | Keeps survivors in the survivor space for up to 15 garbage collections before promotion to the old generation space. |
 
 ## Configure Garbage Collection
 
@@ -70,10 +70,10 @@ Choosing appropriate garbage collector (GC) algorithms helps improve Liferay ins
 | GC Setting | Explanation |
 | :--------- | :---------- |
 | `-XX:+UseParNewGC` | Enables parallel collectors for the new generation. |
-| `-XX:ParallelGCThreads=16` | Allocates 16 threads for parallel garbage collection. Set the number of threads based on the CPU threads available. Report this number on Linux by running `cat /proc/cpuinfo`. The threads use memory from the old generation space. |
+| `-XX:ParallelGCThreads=16` | Allocates 16 threads for parallel garbage collection. Set the number of threads based on the CPU threads available, which you can get on Linux by running `cat /proc/cpuinfo`. The threads use memory from the old generation space. |
 | `-XX:+UseConcMarkSweepGC` | Enables the concurrent mark sweep GC algorithm for the old generation. |
 | `-XX:+CMSParallelRemarkEnabled` | Enables remarking during program execution. |
-| `-XX:+CMSCompactWhenClearAllSoftRefs` | Move memory blocks closer together when using CMS with the clearl all soft refs setting . |
+| `-XX:+CMSCompactWhenClearAllSoftRefs` | Move memory blocks closer together when using CMS with the `ClearAllSoftRefs` setting. |
 | `-XX:CMSInitiatingOccupancyFraction=85` | Initiates CMS when this percent of old generation space is occupied. |
 | `-XX:+CMSScavengeBeforeRemark` | Execute Eden GCs before re-marking objects of CMS. |
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting_up_liferay_dxp.rst
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting_up_liferay_dxp.rst
@@ -8,6 +8,8 @@ Setting Up Liferay DXP
    setting-up-liferay-dxp/activating-liferay-dxp.md
    setting-up-liferay-dxp/initial-instance-localization.md
    setting-up-liferay-dxp/using-a-cdn.md
+   setting-up-liferay-dxp/tuning-liferay.md
+   setting-up-liferay-dxp/tuning-your-jvm.md
    setting-up-liferay-dxp/configuring_mail.rst
    ../../system-administration/file_storage.rst
    ../../system-administration/installing_and_managing_apps.rst
@@ -60,9 +62,13 @@ Clustering for High Availability
 -  :doc:`/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-cluster-link`
 -  :doc:`/installation-and-upgrades/setting-up-liferay-dxp/clustering-for-high-availability/configuring-unicast-over-tcp`
 
+Performance Tuning
+------------------
+
+-  :doc:`/installation-and-upgrades/setting-up-liferay-dxp/tuning-liferay`
+-  :doc:`/installation-and-upgrades/setting-up-liferay-dxp/tuning-your-jvm`
+
 Other Setup Topics
 ------------------
 
--  :doc:`/system-administration/configuring-liferay/adding-custom-fields`
-- Tuning your JVM (Coming soon!)
-- Setting Up Remote Staging (Coming soon!)
+* Setting Up Remote Staging (Coming soon!)


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7848
https://issues.liferay.com/browse/LRDOCS-7716

@jhinkey

- LRDOCS-7634 the conventional file name is portal-developer.properties
- LRDOCS-7848 add tuning-liferay.md and the placeholder tuning-your-jvm.md
- LRDOCS-7848 mention NIO connectors
- LRDOCS-7848 use the portal tag token
- LRDOCS-7716 set heap to 2560m
- LRDOCS-7716 rewrite tuning-your-jvm.md
- LRDOCS-7848 Wordsmithing.
- LRDOCS-7716 Wordsmithing.
