### PR TITLE
[DXP Cloud] LRDOCS-8799 Add note on region-specific CDN limitation

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
@@ -31,6 +31,10 @@ Liferay's Content Delivery Network (CDN) is a built-in feature provided with DXP
 
 ![The CDN's status is visible on the Network page.](./load-balancer/images/02.png)
 
+```note::
+   The CDN is not currently supported for the Dubai/Northern UAE region.
+```
+
 ## Port
 
 You can set which internal port (`targetPort`) the load balancer's service endpoint routes to. DXP Cloud automatically configures the correct port for the services it provides.


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8799

Small change to point out that enabling the CDN is not yet supported for the Dubai/UAE region. I assume from context that this will be available in the future, at which point we would remove this note.