### PR TITLE
[DXP Cloud] LRDOCS-8832 Update information to prevent users creating duplicate custom domains

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
@@ -50,15 +50,28 @@ Follow these steps to add custom domains to environment services via the DXP Clo
 
 1. Click *Update Custom Domains* to finalize the addition.
 
+### Adding a Custom Domain via LCP.json
+
 Alternatively, you can add custom domains to an environment service by adding the `customDomains` property to its `LCP.json` file:
 
 ```json
 {
-  "id": "webserver",
-  "loadBalancer": {
-    "customDomains": ["acme.com", "www.acme.com"]
-  }
+    "id": "webserver",
+    "environments":
+    {
+        "uat":
+        {
+            "loadBalancer":
+            {
+                "customDomains": ["acme.com", "www.acme.com"]
+            }
+        }
+    } 
 }
+```
+
+```important::
+   You must define a specific environment for each added custom domain, and you cannot use the same custom domain for multiple environments (except for `Disaster Recovery environments <../../troubleshooting/configuring-cross-region-disaster-recovery.md>`__ in different regions). This is necessary for DXP Cloud to properly generate certificates and route Users to the correct domian.
 ```
 
 Once a custom domain is added to your service and your changes are deployed, DXP Cloud handles the routing.


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8832

Users adding custom domains to `LCP.json` files may inadvertently add them to every environment for that service, which can cause issues with duplicates. This adds more information to clarify and avoid this scenario.