### PR TITLE
workflow 7.x | im and pm are nonfunctional notification types | LRDOCS-8548

### DIFF
--- a/docs/dxp/7.x/en/process-automation/workflow/developer-guide/workflow-definition-node-reference.md
+++ b/docs/dxp/7.x/en/process-automation/workflow/developer-guide/workflow-definition-node-reference.md
@@ -203,7 +203,7 @@ Here's the `content-review` task from the Category Specific Approval workflow, w
                     <name></name>
                     <template></template>
                     <template-language>text</template-language>
-                    <notification-type>im</notification-type>
+                    <notification-type>user-notification</notification-type>
                 </timer-notification>
             </timer-actions>
         </task-timer>

--- a/docs/dxp/7.x/en/process-automation/workflow/developer-guide/workflow-task-node-reference.md
+++ b/docs/dxp/7.x/en/process-automation/workflow/developer-guide/workflow-task-node-reference.md
@@ -198,7 +198,7 @@ Task timers trigger an action after a specified time period passes. Timers are u
                 <name></name>
                 <template></template>
                 <template-language>text</template-language>
-                <notification-type>im</notification-type>
+                <notification-type>user-notification</notification-type>
             </timer-notification>
         </timer-actions>
     </task-timer>


### PR DESCRIPTION
this only required a minor change to two code snippets, to move from
```
<notification-type>im</notification-type>
```
to
```
<notification-type>user-notification</notification-type>
```
Once the Kaleo Designer PR is merged I might need to revisit this.
https://issues.liferay.com/browse/LRDOCS-8548
cc @sez11a (and Rich you'll have liferay-docs PRs coming your way for this as well)
cc @rafaprax