### PR TITLE
[DXP Cloud] LRDOCS-8845 Add note explaining how auto-scaled instances are charged

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -9,7 +9,7 @@ Using this feature, a service can automatically increase (upscale) the number of
 ```
 
 ```note::
-   Auto-scaling is only available for the Liferay DXP service in production environments. For more information on how auto-scaling is charged, see `How Auto-scaling is Charged <https://help.liferay.com/hc/en-us/articles/360030843592-How-Auto-Scaling-is-charged->`_.
+   Auto-scaling is only available for the Liferay DXP service in production environments. Once auto-scaling is enabled, each extra instance of the service will incur an hourly charge. For more information on how auto-scaling is charged, see `How Auto-scaling is Charged <https://help.liferay.com/hc/en-us/articles/360030843592-How-Auto-Scaling-is-charged->`_.
 ```
 
 ## JVM Memory Configuration


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8845

This only adds a minor note to the Auto Scaling article explaining the hourly charge mechanism. An update was also requested to be made to the Help Center article, but that will be done through: [LRSUPPORT-39292](https://issues.liferay.com/browse/LRSUPPORT-39292)