### PR TITLE
Headless Delivery Landing Page

### DIFF
--- a/docs/dxp/7.x/en/headless-delivery/landing.html
+++ b/docs/dxp/7.x/en/headless-delivery/landing.html
@@ -6,6 +6,10 @@
 		data: {
 			cards: [
 				{
+					sectionName: 'Using Liferay as a Headless Platform',
+					sectionURL: 'headless-delivery/using-liferay-as-a-headless-platform.html',
+				},
+				{
 					sectionName: 'Producing APIs with REST Builder',
 					sectionURL: 'headless-delivery/producing_apis_with_rest_builder.html',
 					showAll: false,


### PR DESCRIPTION
This PR adds _Using Liferay as a Headless Platform_ to the Headless Delivery landing page, see Slack thread: https://liferay.slack.com/archives/CKZUJ01PB/p1612833454213700