### PR TITLE
LRDOCS-8909 Doclib Upgrade Instructions Wordsmithed

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
@@ -20,7 +20,7 @@ The Liferay Home folder is important to back up because it contains the followin
 
 * **Portal properties and system properties:** The Liferay Home folder stores DXP [portal properties files](../reference/portal-properties.md) (e.g., `portal-ext.properties`, `portal-setup-wizard.properties`, etc.) and DXP [system properties files](../reference/system-properties.md) (e.g., `system-ext.properties`).
 
-* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Assets uploaded to the [Documents and Media repository](https://help.liferay.com/hc/en-us/articles/360028810112-Document-Repository-Configuration) are also stored in the `/data` folder, if you're using the default storage configuration (File System store or the Advanced File System store).
+* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Note, the `/data` folder is the default default storage configuration location for the Advanced File System Store and the Simple File System Store [file storage types](../../system-administration/file-storage/configuring-file-storage.md).
 
 * **`/license` folder (Subscription):** Holds the activation key for the Liferay Enterprise Subscription.
 
@@ -53,6 +53,10 @@ mysqldump --databases my-liferay-database > my-liferay-database-backup.sql
 ```
 
 This file can then be backed up. On restoring the database you can import this file into the database to recreate the database state to that of the time you exported the database.
+
+## File Store
+
+Back up your [file store (Document Library)](../../system-administration/file-storage/configuring-file-storage.md). When you upgrade to a new version of DXP, you must either refer to your existing Document Library or copy the Document Library to your new DXP environment.
 
 ## Search Indexes
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
@@ -20,7 +20,7 @@ The Liferay Home folder is important to back up because it contains the followin
 
 * **Portal properties and system properties:** The Liferay Home folder stores DXP [portal properties files](../reference/portal-properties.md) (e.g., `portal-ext.properties`, `portal-setup-wizard.properties`, etc.) and DXP [system properties files](../reference/system-properties.md) (e.g., `system-ext.properties`).
 
-* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Note, the `/data/document_library` folder is the default storage configuration location for the Simple File System Store. The Advanced File System Store requires you to define the storage location [file storage types](../../system-administration/file-storage/configuring-file-storage.md).
+* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Note, the `/data/document_library` folder is the default storage configuration location for the [Simple File System Store](../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md). The [Advanced File System Store](../../system-administration/file-storage/configuring-file-storage.md) requires setting the storage location explicitly.
 
 * **`/license` folder (Subscription):** Holds the activation key for the Liferay Enterprise Subscription.
 
@@ -35,7 +35,7 @@ The Liferay Home folder is important to back up because it contains the followin
 Using a source control repository such as Git, BitBucket, Subversion, or CVS, is a great way to back up your Liferay Home folder.
 
 ```important::
-   If you configured your `Documents and Media repository <https://help.liferay.com/hc/en-us/articles/360028810112-Document-Repository-Configuration>`_ to a location other than the default location, back up that location.
+   If you configured your File Store (Document Library) to a location other than a ``[Liferay Home]/data`` subfolder, back up that location.
 ```
 
 ## Application Server

--- a/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/maintaining-a-liferay-dxp-installation/backing-up.md
@@ -20,7 +20,7 @@ The Liferay Home folder is important to back up because it contains the followin
 
 * **Portal properties and system properties:** The Liferay Home folder stores DXP [portal properties files](../reference/portal-properties.md) (e.g., `portal-ext.properties`, `portal-setup-wizard.properties`, etc.) and DXP [system properties files](../reference/system-properties.md) (e.g., `system-ext.properties`).
 
-* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Note, the `/data` folder is the default default storage configuration location for the Advanced File System Store and the Simple File System Store [file storage types](../../system-administration/file-storage/configuring-file-storage.md).
+* **`/data` folder:** DXP stores configuration files, search indexes, and cache information in Liferay Home's `/data` folder. Note, the `/data/document_library` folder is the default storage configuration location for the Simple File System Store. The Advanced File System Store requires you to define the storage location [file storage types](../../system-administration/file-storage/configuring-file-storage.md).
 
 * **`/license` folder (Subscription):** Holds the activation key for the Liferay Enterprise Subscription.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
@@ -14,7 +14,7 @@ Your current DXP installation's OSGi configurations (7.0+) and properties (such 
 
     * `/license/*`: Activation keys. (Subscription)
     * `/log/*`: Log files.
-    * `/osgi/*.config`: OSGi configuration files.
+    * `/osgi/configs/*.config`: OSGi configuration files.
     * `portal-*.properties`: Portal properties files, such as `portal-ext.properties`.
     * Application server files: Modified scripts and configuration files.
     * `web.xml`: Portal web application descriptor.

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
@@ -21,6 +21,8 @@ Your current DXP installation's OSGi configurations (7.0+) and properties (such 
 
 1. Replace the new installation's `[Liferay Home]/data` folder with the `[Liferay Home]/data` folder from your backup.
 
+1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+
 ## Updating Settings For the Database Upgrade
 
 Upgrade processes in DXP and in some Marketplace apps use portal properties and OSGi configurations. Upgrade processes in your custom code may also require property updates and configuration updates. These settings and updates must be in place _before_ the database upgrade. Other updates can be done after the database upgrade.

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/configuration-and-infrastructure/migrating-configurations-and-properties.md
@@ -21,7 +21,7 @@ Your current DXP installation's OSGi configurations (7.0+) and properties (such 
 
 1. Replace the new installation's `[Liferay Home]/data` folder with the `[Liferay Home]/data` folder from your backup.
 
-1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files).
 
 ## Updating Settings For the Database Upgrade
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
@@ -45,7 +45,7 @@ Here are the steps for upgrading with a Docker image:
 
     * `/log/*`: Log files.
 
-    * `/osgi/*.config`: [OSGi configuration files](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+    * `/osgi/configs/*.config`: [OSGi configuration files](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
 
     * `portal-*.properties`: [Portal properties](../../reference/portal-properties.md) files, such as `portal-ext.properties`.
 
@@ -53,7 +53,7 @@ Here are the steps for upgrading with a Docker image:
 
     * `web.xml`: Portal web application descriptor.
 
-1. Configure the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by exporting it's settings to a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md) to use in your `new-version/osgi` folder.
+1. Configure the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by exporting it's settings to a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md) to use in your `new-version/osgi` folder. This is only required when using Advanced File System Store or when you modified the storage location.
 
 1. Make sure you're using the JDBC database driver your database vendor recommends. If you're using MySQL, for example, set `jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver` in [`new-version/files/portal-ext.properties`](../../reference/portal-properties.md) and replace the MySQL JDBC driver JAR your app server uses. See [Database Drivers](../configuration-and-infrastructure/migrating-configurations-and-properties.md#database-drivers) for more details.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
@@ -45,7 +45,7 @@ Here are the steps for upgrading with a Docker image:
 
     * `/log/*`: Log files.
 
-    * `/osgi/configs/*.config`: [OSGi configuration files](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+    * `/osgi/configs/*.config`: [OSGi configuration files](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md).
 
     * `portal-*.properties`: [Portal properties](../../reference/portal-properties.md) files, such as `portal-ext.properties`.
 
@@ -53,7 +53,15 @@ Here are the steps for upgrading with a Docker image:
 
     * `web.xml`: Portal web application descriptor.
 
-1. Configure the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by exporting it's settings to a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md) to use in your `new-version/osgi` folder. This is only required when using Advanced File System Store or when you modified the storage location.
+1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or if you're using [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your `new-version/osgi/configs` folder.
+
+    ```important::
+       If you're using `Advanced File System Store <../../../system-administration/file-storage/configuring-file-storage.md>`_, you must configure it with a ``.config`` file in the new installation before upgrading the database.
+
+       Here's an example  ``com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.config`` file with the required ``rootDir`` parameter:
+
+       ``rootDir="data/document_library"``
+    ```
 
 1. Make sure you're using the JDBC database driver your database vendor recommends. If you're using MySQL, for example, set `jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver` in [`new-version/files/portal-ext.properties`](../../reference/portal-properties.md) and replace the MySQL JDBC driver JAR your app server uses. See [Database Drivers](../configuration-and-infrastructure/migrating-configurations-and-properties.md#database-drivers) for more details.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
@@ -37,21 +37,23 @@ Here are the steps for upgrading with a Docker image:
 
     * `deploy`: The Docker container copies artifacts from this folder to the container's auto-deploy folder.
 
-1. If you're using an embedded [Elasticsearch](../../../using-search/installing-and-upgrading-a-search-engine/elasticsearch/getting-started-with-elasticsearch.md) engine or a local [File Store \(Document Library\)](../../../system-administration/file-storage/configuring-file-storage.md), copy the `[Liferay Home]/data` folder from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the `files` folder (e.g., creating `new-version/files/data`).
+1. If you're using an embedded [Elasticsearch](../../../using-search/installing-and-upgrading-a-search-engine/elasticsearch/getting-started-with-elasticsearch.md) engine or a local [File Store \(Document Library\)](../../../system-administration/file-storage/configuring-file-storage.md), copy the `[Liferay Home]/data` folder to the new `files` folder to create `new-version/files/data`.
 
-1. Copy and merge the [Liferay Home files](../../maintaining-a-liferay-dxp-installation/backing-up.md#liferay-home) and [application server files](../../maintaining-a-liferay-dxp-installation/backing-up.md#application-server) from your backup to their corresponding locations in the `files` folder (your new `[Liferay Home]`). For example, copy your activation key from `[Liferay Home backup]/license/` to `new-version/files/license/`. The files may include but are not limited to these:
+1. Copy and merge the [Liferay Home files](../../maintaining-a-liferay-dxp-installation/backing-up.md#liferay-home) and [application server files](../../maintaining-a-liferay-dxp-installation/backing-up.md#application-server) from your backup to their corresponding locations in the `files` folder (your new `[Liferay Home]`). For example, copy your activation key to `new-version/files/license/`. The files may include but are not limited to these:
 
     * `/license/*`: Activation keys. (Subscription)
 
     * `/log/*`: Log files.
 
-    * `/osgi/*.config`: OSGi configuration files.
+    * `/osgi/*.config`: [OSGi configuration files](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
 
-    * `portal-*.properties`: Portal properties files, such as `portal-ext.properties`.
+    * `portal-*.properties`: [Portal properties](../../reference/portal-properties.md) files, such as `portal-ext.properties`.
 
     * `setenv.sh`, `startup.sh`, and more: Application server configuration scripts.
 
     * `web.xml`: Portal web application descriptor.
+
+1. Configure the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by exporting it's settings to a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md) to use in your `new-version/osgi` folder.
 
 1. Make sure you're using the JDBC database driver your database vendor recommends. If you're using MySQL, for example, set `jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver` in [`new-version/files/portal-ext.properties`](../../reference/portal-properties.md) and replace the MySQL JDBC driver JAR your app server uses. See [Database Drivers](../configuration-and-infrastructure/migrating-configurations-and-properties.md#database-drivers) for more details.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/upgrading-via-docker.md
@@ -53,7 +53,7 @@ Here are the steps for upgrading with a Docker image:
 
     * `web.xml`: Portal web application descriptor.
 
-1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or if you're using [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your `new-version/osgi/configs` folder.
+1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your `new-version/osgi/configs` folder.
 
     ```important::
        If you're using `Advanced File System Store <../../../system-administration/file-storage/configuring-file-storage.md>`_, you must configure it with a ``.config`` file in the new installation before upgrading the database.

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
@@ -20,6 +20,8 @@ If you're [upgrading to a new Liferay Docker image](../../installing-liferay/usi
 
 1. Replace the new installation's `[Liferay Home]/data` folder with the `[Liferay Home]/data` folder from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md).
 
+1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+
 1. Copy your DXP activation key (Subscription) and your OSGi configuration files from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md#liferay-home) to the new installation.
 
 1. Make sure you're using the JDBC database driver your database vendor recommends. If you're using MySQL, for example, set `jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver` in [`portal-ext.properties`](../../reference/portal-properties.md) and replace the MySQL JDBC driver JAR your app server uses. See [Database Drivers](../configuration-and-infrastructure/migrating-configurations-and-properties.md#database-drivers) for more details.

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
@@ -22,6 +22,12 @@ If you're [upgrading to a new Liferay Docker image](../../installing-liferay/usi
 
 1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
 
+```important::
+If you are using the Advanced File System Store, you must specify the storage location before the upgrade via [`.config` file]. For that, add a file called `com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.config` to `osgi/configs/` setting the `rootDir` parameter. For example:
+
+`rootDir="data/document_library"`
+```
+
 1. Copy your DXP activation key (Subscription) and your OSGi configuration files from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md#liferay-home) to the new installation.
 
 1. Make sure you're using the JDBC database driver your database vendor recommends. If you're using MySQL, for example, set `jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver` in [`portal-ext.properties`](../../reference/portal-properties.md) and replace the MySQL JDBC driver JAR your app server uses. See [Database Drivers](../configuration-and-infrastructure/migrating-configurations-and-properties.md#database-drivers) for more details.
@@ -99,7 +105,7 @@ Now that the database upgrade is complete, test it.
 
     * `/license/*`: Activation keys. (Subscription)
     * `/log/*`: Log files.
-    * `/osgi/*.config`: OSGi configuration files.
+    * `/osgi/configs/*.config`: OSGi configuration files.
     * `portal-*.properties`: Portal properties files, such as `portal-ext.properties`.
     * Application server files: Modified scripts and configuration files.
     * `web.xml`: Portal web application descriptor.

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
@@ -20,13 +20,15 @@ If you're [upgrading to a new Liferay Docker image](../../installing-liferay/usi
 
 1. Replace the new installation's `[Liferay Home]/data` folder with the `[Liferay Home]/data` folder from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md).
 
-1. Set up the [File Store (Document Library)](../../../system-administration/file-storage/configuring-file-storage.md) by copying it from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md) to the new installation and or configuring the new installation to use it via a [`.config` file](../../../system-administration/configuring-liferay/understanding-configuration-scope.md).
+1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or if you're using [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your new `[Liferay Home]/osgi/configs/` folder.
 
-```important::
-If you are using the Advanced File System Store, you must specify the storage location before the upgrade via [`.config` file]. For that, add a file called `com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.config` to `osgi/configs/` setting the `rootDir` parameter. For example:
+    ```important::
+       If you're using `Advanced File System Store <../../../system-administration/file-storage/configuring-file-storage.md>`_, you must configure it with a ``.config`` file in the new installation before upgrading the database.
 
-`rootDir="data/document_library"`
-```
+       Here's an example  ``com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.config`` file with the required ``rootDir`` parameter:
+
+       ``rootDir="data/document_library"``
+    ```
 
 1. Copy your DXP activation key (Subscription) and your OSGi configuration files from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md#liferay-home) to the new installation.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/upgrading-liferay/upgrade-basics/using-the-database-upgrade-tool.md
@@ -20,7 +20,7 @@ If you're [upgrading to a new Liferay Docker image](../../installing-liferay/usi
 
 1. Replace the new installation's `[Liferay Home]/data` folder with the `[Liferay Home]/data` folder from your [backup](../../maintaining-a-liferay-dxp-installation/backing-up.md).
 
-1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or if you're using [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your new `[Liferay Home]/osgi/configs/` folder.
+1. If you're using [Advanced File System Store](../../../system-administration/file-storage/configuring-file-storage.md) or [Simple File System Store](../../../system-administration/file-storage/other-file-store-types/simple-file-system-store.md) with a modified storage location, export your file store settings to a [`.config` file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md#creating-configuration-files) and copy it to your new `[Liferay Home]/osgi/configs/` folder.
 
     ```important::
        If you're using `Advanced File System Store <../../../system-administration/file-storage/configuring-file-storage.md>`_, you must configure it with a ``.config`` file in the new installation before upgrading the database.

--- a/docs/dxp/7.x/en/system-administration/file-storage/configuring-file-storage.md
+++ b/docs/dxp/7.x/en/system-administration/file-storage/configuring-file-storage.md
@@ -6,6 +6,10 @@ Widgets that store files (for example, [Documents and Media](../../../collaborat
    If you are going to production, we highly recommend reviewing the various File Store configuration options and choosing the one that best fits your needs, **before** going live. Doing so can avoid painful file store migrations later in a project's life.
 ```
 
+```note::
+   The file store is also known as the Document Library.
+```
+
 ## Configuring Advanced File System Store
 
 The Advanced File System Store programmatically creates a folder structure that can expand to millions of files, by alphabetically nesting the files in folders. This allows more files to be stored and helps to avoid the limitation that some operating system have on the number of files that can be stored per folder. Storing fewer files per folder also improves file lookup performance.
@@ -20,7 +24,7 @@ To use the Advanced File System store method, following these steps:
     dl.store.impl=com.liferay.portal.store.file.system.AdvancedFileSystemStore
     ```
 
-1. Restart DXP.
+1. Restart Liferay.
 
 1. In the Control Panel, navigate to _Configuration_ &rarr; _System Settings_ &rarr; _File Storage_.
 
@@ -30,7 +34,7 @@ To use the Advanced File System store method, following these steps:
 
 1. Click _Save_.
 
-DXP is now saving files using Advanced File System Store.
+Liferay is now saving files using Advanced File System Store.
 
 ### File Storage in a Clustered Environment
 
@@ -40,7 +44,7 @@ In a [clustered environment](../../../installation-and-upgrades/setting-up-lifer
 
 ### Other File Storage Methods
 
-Liferay DXP also ships with several other file storage methods that can be configured, depending on your project's needs.
+There are other built-in file storage methods available.
 
 * [Simple File System Store](./other-file-store-types/simple-file-system-store.md) uses the file system (local or a mounted share) to store files. This is the *default* file store.
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-8909

@jhinkey

- LRDOCS-8909 Copy or configure the old doc lib to the new installation
- LRDOCS-8909 Advanced File System store does not use data/document_library by default. You need to specify the folder. This was made to avoid issues moving from File System Store to Advance without doing the migrating first
- LRDOCS-8909 Be sure we configure Advanced File System Store
- LRDOCS-8909 Improve doclib upgrade instructions
- LRDOCS-8909 Wordsmithing.
