### PR TITLE
Fixes IBM Cloud Object Storage Typo

### DIFF
--- a/docs/dxp/7.x/en/system-administration/file-storage/other-file-store-types/ibm-cloud-object-storage.md
+++ b/docs/dxp/7.x/en/system-administration/file-storage/other-file-store-types/ibm-cloud-object-storage.md
@@ -23,7 +23,7 @@ Liferay DXP implements IBM’s [Cloud Object Storage](https://cloud.ibm.com/docs
 Once you have the System Settings configuration in place, you must set the IBM Cloud Object Storage store as default. To do this, set the following property in the `portal-ext.properties` file:
 
 ```properties
-dl.store.impl=com.liferay.portal.store.s3.S3Store
+dl.store.impl=com.liferay.portal.store.s3.IBMS3Store
 ```
 
 ## Using the Store in a Clustered Environment


### PR DESCRIPTION
This PR fixes a typo in the IBM Cloud Object Storage article, per comment on [LRDOCS-8935](https://issues.liferay.com/browse/LRDOCS-8935).