### PR TITLE
LRDOCS 7848 7716 tuning liferay jvm 2

### DIFF
--- a/docs/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/reference/portal-properties.md
@@ -150,7 +150,7 @@ mail.session.jndi.name=mail/SomeMailSession
 
 You can add a properties file for a specific environment, such as a development environment. Then you can use a single `portal-ext.properties` for common properties, and an environment-specific configuration for others.
 
-1. Create an arbitrary extension file (e.g., `portal-development.properties`) for your environment and add environment-specific properties to it:
+1. Create an arbitrary extension file (e.g., `portal-developer.properties`) for your environment and add environment-specific properties to it:
 
     ```properties
     mail.session.jndi.name=mail/DevMailSession
@@ -159,16 +159,16 @@ You can add a properties file for a specific environment, such as a development 
 1. Include the new extension file as a properties source by adding this `include-and-override` property to the top of your `portal-ext.properties` file:
 
     ```properties
-    include-and-override=portal-development.properties
+    include-and-override=portal-developer.properties
     ```
 
 Resulting properties source order:
 
 1. `portal-impl.jar/portal.properties`
 1. `[Liferay Home]/portal-ext.properties`
-1. `[Liferay Home]/portal-development.properties`
+1. `[Liferay Home]/portal-developer.properties`
 
-The last value defined for `mail.session.jndi.name` is in `[Liferay Home]/portal-development.properties`.
+The last value defined for `mail.session.jndi.name` is in `[Liferay Home]/portal-developer.properties`.
 
 Resulting configuration:
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
@@ -83,7 +83,7 @@ In Tomcat, the thread pools are configured in the `$CATALINA_HOME/conf/server.xm
 />
 ```
 
-If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, try `maxThreads=300`. Adjust connection pool settings and test your system to find settings that meet your needs.
+If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, set `maxThreads=300`. If you're testing an I/O-based load or you're concerned about I/O capacity, use more threads or switch to using a non-I/O blocking connector. Test your system and adjust connection pool settings to meet your needs.
 
 Additional tuning parameters around `Connector` are available, including the connector types, the connection timeouts, and TCP queue. Consult your application server's documentation for details.
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
@@ -15,7 +15,7 @@ These features help during development but slow down performance. They're not in
 
 ### Portal Developer Properties
 
-Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
 
 ```properties 
 include-and-override=portal-developer.properties

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
@@ -15,7 +15,7 @@ These features help during development but slow down performance. They're not in
 
 ### Portal Developer Properties
 
-Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your `portal-ext.properties` file using this setting:
 
 ```properties 
 include-and-override=portal-developer.properties

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-liferay.md
@@ -1,0 +1,119 @@
+# Tuning Liferay
+
+There are several ways to tune Liferay's performance. This involves configuring the Java Virtual Machine and frameworks that support the Liferay application, monitoring performance and resources, and adjusting settings to meet your needs. Here's an overview of the tuning topics.
+
+## Disable Developer Settings
+
+Here are some of the ways Liferay and its supporting frameworks facilitate development: 
+
+* Accommodate debuggers
+* Perform system checks
+* Upgrade data on startup automatically
+* Poll for code changes to apply automatically
+
+These features help during development but slow down performance. They're not intended for production environments and must therefore be disabled to optimize performance. Start with disabling all developer Portal Properties.
+
+### Portal Developer Properties
+
+Liferay's [Portal Properties](../reference/portal-properties.md) includes several properties that facilitate development. The [`portal-developer.properties`](https://github.com/liferay/liferay-portal/blob/7.3.5-ga6/portal-impl/src/portal-developer.properties) included in your Liferay installation declares all of the properties but is disabled by default. This file is only enabled if you referenced it in your  `portal-developer.properties` file using this setting:
+
+```properties 
+include-and-override=portal-developer.properties
+```
+
+If you included Liferay's `portal-developer.properties` file or included your own developer properties files (e.g., `[Liferay Home]/portal-developer.properties`), disable them by commenting them out in your `portal-ext.properties` file:
+
+```properties 
+#include-and-override=portal-developer.properties
+#include-and-override=${liferay.home}/portal-developer.properties
+```
+
+Similarly, if you enabled any developer properties individually, comment them out too.
+
+Next, disable developer settings in your JSP engine.
+
+### JSP Engine Settings
+
+Many application servers' JSP Engines are set for development by default. Deactivate these settings prior to entering production:
+
+**Development mode:** This makes the JSP container poll the file system for changes to JSP files. Since you don't change JSPs on-the-fly like this in production, turn off this mode.
+
+**Mapped File:** In development, it's typical to generate static content with one print statement versus one statement per line of JSP text. In production, opt for the latter.
+
+To disable development mode and the mapped file in Tomcat, for example, update the `$CATALINA_HOME/conf/web.xml` file's JSP servlet configuration to this:
+
+```xml
+<servlet>
+    <servlet-name>jsp</servlet-name>
+    <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>   
+    <init-param>
+        <param-name>development</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <init-param>
+        <param-name>mappedFile</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>3</load-on-startup>
+</servlet>
+```
+
+Development mode and the mapped file are disabled.
+
+## Thread Pool 
+
+Each request to the application server consumes a worker thread for the duration of the request. When no threads are available to process requests, the request is queued to wait for the next available worker thread. In a finely tuned system, the number of threads in the thread pool are balanced with the total number of concurrent requests. There should not be a significant amount of threads left idle to service requests.
+
+Use an initial thread pool setting of 50 threads and then monitor it within your application server's monitoring consoles. You may wish to use a higher number (e.g., 250) if your average page times are in the 2-3 second range. Too few threads in the thread pool might queue excessive requests; too many threads can cause excessive context switching.
+
+In Tomcat, the thread pools are configured in the `$CATALINA_HOME/conf/server.xml` file's `Connector` element. The [Apache Tomcat documentation](https://tomcat.apache.org/tomcat-9.0-doc/config/http.html) provides more details. Here's an example thread pool configuration:
+
+```xml
+<Connector
+    address="xxx.xxx.xxx.xxx"
+    connectionTimeout="600000"
+    maxConnections="16384"
+    maxKeepAliveRequests="-1"
+    maxThreads="75"
+    minSpareThreads="50"
+    port="8080"
+    redirectPort="8443"
+    socketBuffer="-1"
+    URIEncoding="UTF-8"
+/>
+```
+
+If you're testing a CPU-based load or if you're concerned about CPU capacity,  test using approximately 75 threads for every hardware thread available. For example, if your machine has 4 hardware threads, try `maxThreads=300`. Adjust connection pool settings and test your system to find settings that meet your needs.
+
+Additional tuning parameters around `Connector` are available, including the connector types, the connection timeouts, and TCP queue. Consult your application server's documentation for details.
+
+## Database Connection Pool
+
+Database connection pools manage database connections for reuse, saving you from opening new connections with every new request. Liferay can use C3PO, DBCP, HikariCP, or Tomcat for connection pooling. The connection pool provider is set using the `jdbc.default.liferay.pool.provider` [Portal Property](../reference/portal-properties.md). HikariCP is the default.
+
+The database connection pool should be roughly 30-40% of the thread pool size. It provides a connection whenever Liferay needs to retrieve data from the database (e.g., user login). If the pool size is too small, requests queue in the server waiting for database connections. If the size is too large, however, idle database connections waste resources. As with thread pools, monitor these settings and adjust them based on your performance tests.
+
+In Tomcat, the connection pools are configured in the Resource elements in `$CATALINA_HOME/conf/Catalina/localhost/ROOT.xml`. Here's an example connection pool configuration:
+
+```xml
+<Resource
+    acquireIncrement="5"
+    auth="Container"
+    description="Liferay DB Connection"
+    driverClass="[place the driver class name here]"
+    factory="org.apache.naming.factory.BeanFactory"
+    jdbcUrl="[place the URL to your database here]"
+    maxPoolSize="75"
+    minPoolSize="10"
+    name="jdbc/LiferayPool"
+    password="[place your password here]"
+    type="com.mchange.v2.c3p0.ComboPooledDataSource"
+    user="[place your user name here]"
+/>
+```
+
+This configuration starts with 10 connections and increments by 5 as needed to a maximum of 75 connections in the pool.
+
+## Java Virtual Machine
+
+Your application server runs in a Java Virtual Machine (JVM). Memory management and garbage collection affect how fast Liferay responds to user requests. Please see [Tuning Your JVM](./tuning-your-jvm.md) for instructions next.

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
@@ -1,3 +1,103 @@
-# Tuning Your JVM 
+# Tuning Your JVM
 
-Coming soon!
+Java Virtual Machine (JVM) tuning primarily focuses on adjusting the garbage collector and the Java memory heap. We used Oracle's 1.8 JVM for the reference architecture. You may choose other supported JVM versions and implementations. Please consult the  [Liferay DXP Compatibility Matrix](https://web.liferay.com/group/customer/dxp/support/compatibility-matrix) for additional compatible JVMs.
+
+Here are the JVM tuning topics:
+
+* [Garbage Collector](#garbage-collector)
+* [Code Cache](#code-cache)
+* [Java Heap](#java-heap)
+* [JVM Advanced Options](#jvm-advanced-options)
+
+Garbage collection is first.
+
+## Garbage Collector
+
+Choosing the appropriate garbage collector (GC) helps improve the responsiveness of your Liferay DXP deployment. Use the concurrent low pause collectors:
+
+```bash
+-XX:+UseParNewGC -XX:ParallelGCThreads=16 -XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled -XX:+CMSCompactWhenClearAllSoftRefs
+-XX:CMSInitiatingOccupancyFraction=85 -XX:+CMSScavengeBeforeRemark
+```
+
+You may choose from other available GC algorithms, including parallel throughput collectors and G1 collectors. Start tuning using parallel collectors in the new generation and concurrent mark sweep (CMS) in the old generation.
+
+**Note:** the `ParallelGCThreads` value (e.g., `ParallelGCThreads=16`) varies  based on the type of CPUs available. Set the value according to CPU specification. On Linux machines, report the number of available CPUs by running `cat /proc/cpuinfo`.
+
+**Note:** There are additional "new" algorithms like G1, but Liferay Engineering's tests for G1 indicated that it does not improve performance. Since your application performance may vary, you should add G1 to your testing and tuning plans.
+
+## Code Cache
+
+Java's just-in-time (JIT) compiler generates native code to improve performance. The default size is `48m`. This may not be sufficient for larger applications. Too small a code cache reduces performance, as the JIT isn't able to optimize high frequency methods. For Liferay DXP,  start with `64m` for the initial code cache size.
+
+```bash
+-XX:InitialCodeCacheSize=64m -XX:ReservedCodeCacheSize=96m
+```
+
+Examine the efficacy of the parameter changes by adding the following logging parameters:
+
+```bash
+-XX:+PrintCodeCache -XX:+PrintCodeCacheOnCompilation
+```
+
+## Java Heap
+
+When most people think about tuning the Java memory heap, they think of setting the maximum and minimum memory of the heap. Unfortunately, most deployments require far more sophisticated heap tuning to obtain optimal performance, including tuning the young generation size, tenuring durations, survivor spaces, and many other JVM internals.
+
+For most systems, it's best to start with at least the following memory settings:
+
+```bash
+server -XX:NewSize=700m -XX:MaxNewSize=700m -Xms2560m -Xmx2560m -XX:MetaspaceSize=512m
+-XX:MaxMetaspaceSize=512m -XX:SurvivorRatio=6 -XX:TargetSurvivorRatio=9 -XX:MaxTenuringThreshold=15
+```
+
+On systems that require large heap sizes (e.g., above 4GB), it may be beneficial to use large page sizes. You can activate large page sizes like this:
+
+```bash
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+```
+
+You may choose to specify different page sizes based on your application profile.
+
+**Note:** To use large pages in the JVM, you must configure your underlying operating system to activate them. In Linux, run `cat /proc/meminfo` and look at
+"huge page" items.
+
+```note::
+   **Caution:** Avoid allocating more than 32GB to your JVM heap. Your heap size should be commensurate with the speed and quantity of available CPU resources.
+```
+
+## JVM Advanced Options
+
+The following advanced JVM options were also applied in the Liferay benchmark environment:
+
+```bash
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+-XX:+UseCompressedOops -XX:+DisableExplicitGC -XX:-UseBiasedLocking
+-XX:+BindGCTaskThreadsToCPUs -XX:UseFastAccessorMethods
+```
+
+Please consult your JVM documentation for additional details on advanced JVM options.
+
+Combining the above recommendations together, makes this configuration:
+
+```bash
+server -XX:NewSize=1024m -XX:MaxNewSize=1024m -Xms4096m
+-Xmx4096m -XX:MetaspaceSize=512m -XX:MaxMetaspaceSize=512m
+-XX:SurvivorRatio=12 -XX:TargetSurvivorRatio=90
+-XX:MaxTenuringThreshold=15 -XX:+UseLargePages
+-XX:LargePageSizeInBytes=256m -XX:+UseParNewGC
+-XX:ParallelGCThreads=16 -XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled -XX:+CMSCompactWhenClearAllSoftRefs
+-XX:CMSInitiatingOccupancyFraction=85 -XX:+CMSScavengeBeforeRemark
+-XX:+UseLargePages -XX:LargePageSizeInBytes=256m
+-XX:+UseCompressedOops -XX:+DisableExplicitGC -XX:-UseBiasedLocking
+-XX:+BindGCTaskThreadsToCPUs -XX:+UseFastAccessorMethods
+-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=96m
+```
+
+```note::
+   **Caution:** The above JVM settings should formulate a starting point for your performance tuning. Every system's final parameters vary due to many factors, including number of current users and transaction speed.
+```
+
+Monitor the garbage collector statistics to ensure your environment has sufficient allocations for metaspace and also for the survivor spaces. Using the configuration above in the wrong environment could result in dangerous runtime scenarios like out of memory failures. Improperly tuned survivor spaces also lead to wasted heap space.

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
@@ -2,7 +2,7 @@
 
 Java Virtual Machine (JVM) tuning primarily focuses on adjusting Java heap and non-heap settings and configuring garbage collection. Finding settings that perform well for you depend on your system's load and your hardware. The settings discussed here can be used as a starting point for tuning your JVM. 
 
-Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for compatible JVMs.
+You can adapt the example Oracle JVM settings to settings for your JVM. Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for compatible JVMs.
 
 ## Set Heap and Non-Heap Space
 

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
@@ -1,0 +1,3 @@
+# Tuning Your JVM 
+
+Coming soon!

--- a/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
+++ b/docs/dxp/7.x/en/installation-and-upgrades/setting-up-liferay/tuning-your-jvm.md
@@ -2,7 +2,7 @@
 
 Java Virtual Machine (JVM) tuning primarily focuses on adjusting Java heap and non-heap settings and configuring garbage collection. Finding settings that perform well for you depend on your system's load and your hardware. The settings discussed here can be used as a starting point for tuning your JVM. 
 
-We used Oracle's 1.8 JVM for the reference architecture. You may choose other supported JVM versions and implementations. Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for additional compatible JVMs.
+Please consult [the compatibility matrix](https://help.liferay.com/hc/en-us/articles/360049238151) for compatible JVMs.
 
 ## Set Heap and Non-Heap Space
 
@@ -22,7 +22,7 @@ The JVM's memory comprises heap and non-heap spaces. The heap contains a space f
 | Memory Setting | Explanation |
 | :------ | :---------- |
 | `-Xms2560m` | Initial space for heap. |
-| `-Xmx2560m` | Maximim space for heap. |
+| `-Xmx2560m` | Maximum space for heap. |
 | `-XX:NewSize=1536m`| Initial new space. Setting the new size to half of the total heap typically provides better performance than using a smaller new size. |
 | `-XX:MaxNewSize=1536m` | Maximum new space. |
 | `-XX:MetaspaceSize=768m` | Initial space for static content. |
@@ -50,7 +50,7 @@ In the old generation space (in the heap), large garbage collections can cause n
 | :------ | :---------- |
 | `-XX:SurvivorRatio=16` | Makes the survivor space 1/16 of the new space (the initial new space is `1536m`). |
 | `-XX:TargetSurvivorRatio=50` | Instructs the JVM to use 50% of the survivor space after each Eden garbage collection. |
-| `-XX:MaxTenuringThreshold=15` | Keeps survivors to stay in the survivor space for up to 15 garbage collections before promotion to the old generation space. |
+| `-XX:MaxTenuringThreshold=15` | Keeps survivors in the survivor space for up to 15 garbage collections before promotion to the old generation space. |
 
 ## Configure Garbage Collection
 
@@ -70,10 +70,10 @@ Choosing appropriate garbage collector (GC) algorithms helps improve Liferay ins
 | GC Setting | Explanation |
 | :--------- | :---------- |
 | `-XX:+UseParNewGC` | Enables parallel collectors for the new generation. |
-| `-XX:ParallelGCThreads=16` | Allocates 16 threads for parallel garbage collection. Set the number of threads based on the CPU threads available. Report this number on Linux by running `cat /proc/cpuinfo`. The threads use memory from the old generation space. |
+| `-XX:ParallelGCThreads=16` | Allocates 16 threads for parallel garbage collection. Set the number of threads based on the CPU threads available, which you can get on Linux by running `cat /proc/cpuinfo`. The threads use memory from the old generation space. |
 | `-XX:+UseConcMarkSweepGC` | Enables the concurrent mark sweep GC algorithm for the old generation. |
 | `-XX:+CMSParallelRemarkEnabled` | Enables remarking during program execution. |
-| `-XX:+CMSCompactWhenClearAllSoftRefs` | Move memory blocks closer together when using CMS with the clearl all soft refs setting . |
+| `-XX:+CMSCompactWhenClearAllSoftRefs` | Move memory blocks closer together when using CMS with the `ClearAllSoftRefs` setting. |
 | `-XX:CMSInitiatingOccupancyFraction=85` | Initiates CMS when this percent of old generation space is occupied. |
 | `-XX:+CMSScavengeBeforeRemark` | Execute Eden GCs before re-marking objects of CMS. |
 

--- a/readme/EXAMPLE_CODE_GUIDELINES.md
+++ b/readme/EXAMPLE_CODE_GUIDELINES.md
@@ -1,0 +1,309 @@
+# Example Code Guidelines
+
+## Table of Contents
+
+* [Purpose](#purpose)
+* [Creating an Example Project](#creating-an-example-project)
+    * [Example Project Structure](#example-project-structure)
+    * [Create an Example Project](#create-an-example-project)
+* [Guidelines](#guidelines)
+    * [Module Structure](#module-structure)
+        * [API Module Structure](#api-module-structure)
+        * [Impl Module Structure](#impl-module-structure)
+        * [Web Module Structure](#web-module-structure)
+    * [bnd.bnd](#bndbnd)
+        * [Initial Bnd Content](#initial-bnd-content)
+        * [Export API Packages](#export-api-packages)
+    * [build.gradle](#buildgradle)
+    * [Packages](#packages)
+        * [Implementation PackageNames](#implementation-package-names)
+    * [Classes](#classes)
+        * [Class Names](#class-names)
+        * [Component Annotations](#component-annotations)
+    * [Logic](#logic)
+        * [Localization](#localization)
+            * [Labels and Headings](#labels-and-headings)
+            * [Using Language Keys](#using-language-keys)
+        * [Logging Output](#logging-output)
+    * [Templates](#templates)
+
+## Purpose
+
+This document provides guidelines for tutorial example code. It demonstrates starting an example project, describes code example rules, and describes the code review process.
+
+## Creating an Example Project
+
+Here you'll learn how to create an example project to accompany your developer tutorial. It will be a Java project that uses Liferay Workspace.
+
+> Prerequisite: A Java 8 JDK (such as [Azul Zulu Java 8](https://www.azul.com/downloads/zulu-community/?version=java-8-lts&package=jdk)). See the [Compatibility Matrix](https://help.liferay.com/hc/en-us/articles/360049238151).
+
+### Example Project Structure
+
+Here's the structure for an example project that has the ID `c3p0` (more on project IDs shortly). The project is shown alongside its tutorial called `implementing-something.md`:
+
+```
+[tutorial path] // This is the same folder your article will go in later.
+└── implementing-something/resources/liferay-c3p0.zip/
+    └── c3p0-impl // Module
+        ├── bnd.bnd
+        ├── build.gradle
+        └── src/main/java/ // Your Java code goes here
+```
+
+You only need to create two module files:
+1. `bnd.bnd`
+1. `build.gradle`
+
+Our `update_tutorials.sh` script creates the rest. Create your own project next.
+
+### Create an Example Project
+
+1. Decide on your example's *unique* four-character ID, following the ID pattern below.
+
+   ID Pattern:
+   ```
+   [a-z][0-9][a-z][0-9]
+   ```
+   
+   Example: `c3p0`
+
+    For convenience, these steps use `xxxx` as an ID placeholder--replace it with your unique ID.
+
+    > Tip: Make sure your ID is unique by searching the your liferay-learn branch for any project folders that use the ID. For example, `find . -name liferay-c3p0.zip`
+
+1. Create your `liferay-xxxx.zip` example project folder in a `[tutorial-name]/resources/` folder, that is alongside your tutorial Markdown file.
+
+    ```
+    [tutorial path]
+    └── [tutorial-name]/resources/liferay-xxxx.zip
+    ```
+
+1. In your project, create module(s) whose root folders follow these naming conventions:
+
+    | Example Folder Name | Description |
+    | :-------------- | :---------- |
+    | xxxx-api | Contains an API. |
+    | xxxx-impl | Contains an implementation. |
+    | xxxx-web | Contains a web application, such as a portlet. |
+    
+    You can create modules any way you like (e.g., manually, using [Liferay Dev Studio](https://liferay.dev/-/ide), using [Blade CLI](https://help.liferay.com/hc/en-us/articles/360029147071-Blade-CLI), and more).
+
+1. In each module folder, create a `bnd.bnd` file. Here is example Bnd content for the different modules types.
+
+    | Module Type | Bnd Content |
+    | :---------- | :---------- |
+    | API | Bundle-Name: Acme XXXX API<br>Bundle-SymbolicName: com.acme.xxxx.api<br>Bundle-Version: 1.0.0 |
+    | Implementation | Bundle-Name: Acme XXXX Implementation<br>Bundle-SymbolicName: com.acme.xxxx.impl<br>Bundle-Version: 1.0.0 |
+    | Portlet/Web App | Bundle-Name: Acme XXXX Web<br>Bundle-SymbolicName: com.acme.xxxx.web<br>Bundle-Version: 1.0.0 |
+
+1. In your module, create a `build.gradle` file that depends on `release.portal.api` or `release.dxp.api` (for DXP-only features). For example,
+
+    ```
+    dependencies {
+    	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+    }
+    ```
+
+1. In your module, create a `src/main/java` folder for your Java code.
+
+1. Copy our Java Workspace template to your project and build your project by running the `update_examples.sh` script from the `liferay-learn/docs` folder. For example,
+
+    ```bash
+    ./update_examples.sh c3p0
+    ```
+    
+    Here's the file structure with the files added by `update_examples.sh`.
+    
+
+```
+[tutorial path]
+└── implementing-something/resources/liferay-c3p0.zip/
+    ├── gradle.properties // Specifies the Liferay product/version to build against
+    ├── gradlew // Gradle wrapper
+    ├── gradlew.bat // Gradle wrapper (Windows)
+    ├── settings.gradle // Specifies the artifact repository
+    ├── source-formatter-suppressions.xml // Suppresses unneeded code format checks
+    └── c3p0-impl // Module
+        ├── bnd.bnd
+        └── build.gradle
+```
+
+Congratulations! Your tutorial now has an example project that uses Liferay Workspace. Develop your example next.
+
+## Guidelines 
+
+Here are the rules and guidelines for example code.
+
+### Module Structure
+
+Java projects can have one or more modules. All of a project's modules go in the project folder (e.g., `liferay-xxxx.zip` folder)
+
+#### API Module Structure
+
+```
+xxxx-web // Web Module
+├── bnd.bnd
+├── build.gradle
+└── src/main/
+    └── java/
+        └── com/acme/xxxx/DescribesWhatItDoes.java
+```
+
+#### Impl Module Structure
+
+```
+xxxx-impl
+├── bnd.bnd
+├── build.gradle
+└── src/main/
+    ├── java/ // Put Java classes here
+    └── resources/
+        └── content/
+            └── Language.properties // (Optional)
+```
+
+#### Web Module Structure
+
+```
+xxxx-web // Web Module
+├── bnd.bnd
+├── build.gradle
+└── src/main/
+    ├── java/
+    |   └── com/acme/xxxx/web/internal/portlet/XXXXPortlet.java
+    └── resources/
+        ├── content/
+        |   └── Language.properties
+        └── META-INF/resources/ // Put Templates (JSPs) here
+            ├── view_1.jsp
+            └── view_2.jsp
+```
+
+### bnd.bnd
+
+In each module folder, create a `bnd.bnd` file.
+
+#### Initial Bnd Content
+
+Here is example initial Bnd content for the different modules types.
+
+| Module Type | Bnd Content |
+| :---------- | :---------- |
+| API | Bundle-Name: Acme XXXX API<br>Bundle-SymbolicName: com.acme.xxxx.api<br>Bundle-Version: 1.0.0 |
+| Implementation | Bundle-Name: Acme XXXX Implementation<br>Bundle-SymbolicName: com.acme.xxxx.impl<br>Bundle-Version: 1.0.0 |
+| Portlet/Web App | Bundle-Name: Acme XXXX Web<br>Bundle-SymbolicName: com.acme.xxxx.web<br>Bundle-Version: 1.0.0 |
+
+#### Export API Packages 
+
+If you've defined APIs in your module, export their packages in your `bnd.bnd`.
+
+For example, the `k8s2-api` module publishes its com.acme.k8s2.Greeter interface by exporting the `com.acme.k8s2` package in the module's `bnd.bnd`:
+
+```properties
+Export-Package: com.acme.k8s2 
+```
+
+## build.gradle
+
+Make sure your `build.gradle` file sets a dependency on `release.portal.api`, unless you're demonstrating a DXP-only feature--In which case use `release.dxp.api`. Here's your typical `build.gradle` starting content:
+
+```
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}
+```
+
+## Packages
+
+Start package names with this pattern:
+
+```
+com.acme.[ID]
+```
+
+### Implementation Package Names
+
+An implementation package should resemble the interface package but be *internal*. The table below shows the class packages and names for an interface and an implementation of that interface--the similarities are in bold.
+
+| Class Type | Fully Qualified Class Name |
+| :--------- | :------------------------- |
+| Interface | com.liferay.**dynamic.data.mapping.storage**.**DDMStorageAdapter** |
+| Implementation | com.acme.r2f1.internal.**dynamic.data.mapping.storage**.R2F1**DDMStorageAdapter** |
+
+## Classes
+
+### Class Names
+
+In most cases, prefix class names with the project ID (capitalized).
+
+
+| Class Type | Class Name |
+| :--------- | :------------------------- |
+| Interface | *DescribeWhatItIs* (e.g., `Greeter`) |
+| Implementation | XXXX*InterfaceName* (e.g., `C3P0Greeter`) |
+| Portlet | XXXXPortlet (e.g., `C3P0Portlet`)|
+
+### Component Annotations
+
+#### immediate = true
+
+Don't use the `immediate = true` property. Use it only if testing shows that you need it. You should only need it if the class must perform an initialization before it's used.
+
+## Logic
+
+### Localization 
+
+If your module uses localized content, specify the content using language property files (*Language Keys*). Put your default Language Keys in this file:
+
+`src/main/resources/content/Language.properties`
+
+#### Labels and Headings
+
+Include the project ID in labels and headings. For example, `c1n4` is the project ID used in these Language Keys:
+
+```properties
+c1n4-commerce-product-type=C1N4 Commerce Product Type
+c1n4-screen-navigation-entry=C1N4 Screen Navigation Entry
+```
+
+#### Using Language Keys
+
+Access Language Keys with resource bundles. Here's an example of returning a Language Key.
+
+```java 
+ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+    "content.Language", locale, getClass());
+
+return LanguageUtil.get(resourceBundle, "c1n4-commerce-product-type");
+```
+
+### Logging Output
+
+If you want to print messages, use a logger.
+
+Import:
+
+```java 
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+```
+
+Field:
+
+```java 
+private static final Log _log = LogFactoryUtil.getLog(
+		R2F1DDMStorageAdapter.class);
+``` 
+
+Logging Logic:
+
+```java
+    if (_log.isWarnEnabled()) {
+		_log.warn("Acme storage adapter's save method was invoked");
+	}
+```
+
+## Templates
+
+Put templates in your web module's `src/main/resources/META-INF/resources/` folder.
+
+If your module uses a generic view JSP, name it `view.jsp`. If it has more than one, name them `view_1.jsp`, `view_2.jsp`, etc.


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7848
https://issues.liferay.com/browse/LRDOCS-7716

Forwarding with no changes. 

@jhinkey

- LRDOCS-7634 the conventional file name is portal-developer.properties
- LRDOCS-7848 add tuning-liferay.md and the placeholder tuning-your-jvm.md
- LRDOCS-7848 mention NIO connectors
- LRDOCS-7848 use the portal tag token
- LRDOCS-7716 set heap to 2560m
- LRDOCS-7716 rewrite tuning-your-jvm.md
- LRDOCS-7848 Wordsmithing.
- LRDOCS-7716 Wordsmithing.
- LRDOCS-7716 The example settings are specific to Oracle's JVM
- LRDOCS-7848 Update db connection pool tuning
