### PR TITLE
[DXP Cloud] LRDOCS-9016 DXP Cloud Limitations

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
@@ -6,6 +6,8 @@ Liferay DXP Cloud provides a VPN client-to-site connection that has port forward
 
 Subscribers can use redundant VPN tunnels by mapping their connections between their DXP Cloud services to their corresponding VPN server's IP addresses. The redundancy is placed in different availability zones to provide resiliency. The client-to-site approach covers connecting to a service running on the company network. This model is recommended for the containerized architecture and Kubernetes network layer provided.
 
+See the [VPN server limitations](../../reference/dxp-cloud-limitations.md#vpn-servers) section for more information.
+
 ## Configuration
 
 The client to site VPN feature supports the following protocols:

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -48,6 +48,8 @@ Users can view allocated resources from the DXP Cloud console.
 
 With Liferay DXP Cloud, you can integrate [Dynatrace's](https://www.dynatrace.com/) advanced performance monitoring with your production environments.
 
+See the [Dynatrace limitations](../reference/dxp-cloud-limitations.md#dynatrace) for more information.
+
 ### Integrating Dynatrace with Production Environments
 
 Follow these steps to integrate Dynatrace:

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
@@ -8,6 +8,8 @@ From the Backups page in `prd` environments, you can create backups, view or dow
 
 You can also configure the backup service to meet your project's needs via the DXP Cloud console or the backup service's `LCP.json` file.
 
+See the [Backup service limitations](../../reference/dxp-cloud-limitations.md#backup-service) section for more information.
+
 ## The Backups Page
 
 From the Backups page in `prd` environments, you can view backup service information and retained backups, create manual backups, and more.

--- a/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
@@ -12,6 +12,8 @@ By default, this automated build will compile code and can be configured to exec
    Continuous integration only works if you deploy from GitHub, GitLab, or Bitbucket, not the CLI.
 ```
 
+See the [CI service limitations](../reference/dxp-cloud-limitations.md#continuous-integration-service) for more information.
+
 ## Using the Default Jenkinsfile
 
 Starting with CI service version `liferaycloud/jenkins:2.222.1-3.2.0`, a default Jenkinsfile is available when it is not overridden. The default Jenkinsfile is always available for use for projects [using version 4.x.x services](../reference/understanding-service-stack-versions.md).

--- a/docs/dxp-cloud/latest/en/platform-services/database-service/database-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/database-service/database-service.md
@@ -4,6 +4,8 @@ The database service (MySQL) is a distributed relational database service that s
 
 ![Figure 1: The database service is one of several services available in DXP Cloud.](./database-service/images/01.png)
 
+See the [Database service limitations](../../reference/dxp-cloud-limitations.md#database-service) section for more information.
+
 ## Environment Variables
 
 You can set these environment variables to configure the database service. When setting `LCP_MASTER_USER_NAME`, `LCP_MASTER_USER_PASSWORD`, and `LCP_DBNAME`, make sure to use the same values for other services that depend on the database service (e.g., the backup and Liferay DXP services). You should set these variables before the first deployment. If a build is generated with new values for these variables, subsequent deployments will fail. It may be viable in a development environment to delete services and update the `LCP.json` file with new values for these variables, but this isn't viable in a production environment.
@@ -31,5 +33,6 @@ Name                                   | Acceptable Value | Default Value |
 ## Related Information
 
 * [Changing Your Database Username](./changing-your-database-username.md)
-* [Changing your Database Password](./changing-your-database-password.md)
+* [Changing Your Database Password](./changing-your-database-password.md)
+* [Database Service Limitations](../../reference/dxp-cloud-limitations.md#database-service)
 * [Using the MySQL Client](../../using-the-liferay-dxp-service/using-the-mysql-client.md)

--- a/docs/dxp-cloud/latest/en/platform-services/search-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/search-service.md
@@ -6,6 +6,8 @@ services in your application, not with the outside internet.
 
 ![Figure 1: The Elasticsearch service is one of several services available in DXP Cloud.](./search-service/images/01.png)
 
+See the [Search service limitations](../reference/dxp-cloud-limitations.md#search-service) section for more information.
+
 ## Configurations
 
 Although DXP Cloud's services are fine-tuned to work well by default, you may 

--- a/docs/dxp-cloud/latest/en/platform-services/search-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/search-service.md
@@ -24,6 +24,10 @@ correct folder:
     │           └── elasticsearch.yml
     └── LCP.json
 
+```important::
+   You must use the ``elasticsearch.yml`` configuration file to configure Elasticsearch. Configuring Elasticsearch through the UI will be overwritten on each deployment.
+```
+
 ```note::
    If you are using version 3.x.x services, then these configuration files instead belong in the appropriate ``lcp/search/config/{ENV}/`` folder. See `Understanding Service Stack Versions <../reference/understanding-service-stack-versions.md>`__ for more information on checking the version.
 ```

--- a/docs/dxp-cloud/latest/en/platform-services/using-a-custom-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/using-a-custom-service.md
@@ -8,6 +8,8 @@ DXP Cloud allows you to run more than just the standard set of services provided
 
 DXP Cloud uses Docker images as the basis for its services. If you want to run these services locally, [install Docker](https://docs.docker.com/get-docker/) on your local system.
 
+See the [custom services limitations](../reference/dxp-cloud-limitations.md#custom-services) for more information.
+
 ## Adding a Custom Service
 
 Use the following steps to add your own custom service to a build in DXP Cloud:

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -6,6 +6,8 @@ high-performance web server.
 
 ![Figure 1: The web server is one of several services available in DXP Cloud.](./web-server-service/images/01.png)
 
+See the [Web server service limitations](../dxp-cloud-limitations.md#web-server-service) section for more information.
+
 ## Configurations
 
 Although DXP Cloud's services are fine-tuned to work well by default, you may 

--- a/docs/dxp-cloud/latest/en/reference.rst
+++ b/docs/dxp-cloud/latest/en/reference.rst
@@ -11,7 +11,7 @@ Reference
    reference/dxp-cloud-project-changes-in-version-4.md
    reference/command-line-tool.md
    reference/defining-environment-variables.md
-   reference/dxp-cloud-limitations.md
+   reference/platform-limitations.md
 
 .. include:: /reference/README.rst
 	:start-line: 2

--- a/docs/dxp-cloud/latest/en/reference.rst
+++ b/docs/dxp-cloud/latest/en/reference.rst
@@ -11,6 +11,7 @@ Reference
    reference/dxp-cloud-project-changes-in-version-4.md
    reference/command-line-tool.md
    reference/defining-environment-variables.md
+   reference/dxp-cloud-limitations.md
 
 .. include:: /reference/README.rst
 	:start-line: 2

--- a/docs/dxp-cloud/latest/en/reference/README.rst
+++ b/docs/dxp-cloud/latest/en/reference/README.rst
@@ -7,3 +7,4 @@ Reference
 -  :doc:`/reference/dxp-cloud-project-changes-in-version-4`
 -  :doc:`/reference/command-line-tool`
 -  :doc:`/reference/defining-environment-variables`
+-  :doc:`/reference/dxp-cloud-limitations`

--- a/docs/dxp-cloud/latest/en/reference/README.rst
+++ b/docs/dxp-cloud/latest/en/reference/README.rst
@@ -7,4 +7,4 @@ Reference
 -  :doc:`/reference/dxp-cloud-project-changes-in-version-4`
 -  :doc:`/reference/command-line-tool`
 -  :doc:`/reference/defining-environment-variables`
--  :doc:`/reference/dxp-cloud-limitations`
+-  :doc:`/reference/platform-limitations`

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-limitations.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-limitations.md
@@ -1,0 +1,179 @@
+# DXP Cloud Limitations
+
+In addition to a collection of features designed to help address development challenges, DXP Cloud also has a number of limitations due to the technologies and underlying infrastructure used to support it. Many of these limitations may vary due to your specific level of subscription. Other limitations may change over time as changes are made to DXP Cloud's infrastructure.
+
+## Overview
+
+Take these general limitations into consideration when planning to use DXP Cloud:
+
+* Limits apply on the available CPUs, memory, scaling, network configurations (domains, SSL certificates, and IP addresses), and VPN bandwidth for each service. For instance, each service is limited to a maximum 200 GB RAM, and custom domains are limited to 50 or 1500 depending on your web server's configuration.
+
+* Concurrent operations (such as uploads), build size, concurrent builds, and backups also have limitations.
+
+* Service downtimes will occur (especially for environments with only a single instance of Liferay and Search services) at times for planned maintenance.
+
+* A private cluster subscription may be needed for more stringent security, compliance, or VPN requirements.
+
+* Remote Staging is not supported on DXP Cloud.
+
+See the further sections below for more details.
+
+* [All Services](#all-services)
+* [Liferay Service](#liferay-service)
+* [Database Service](#database-service)
+* [Search Service](#search-service)
+* [Backup Service](#backup-service)
+* [Web Server Service](#web-server-service)
+* [Continuous Integration Service](#continuous-integration-service)
+* [Custom Services](#custom-services)
+* [Security](#security)
+
+## All Services
+
+These limitations apply to every service in a DXP Cloud environment:
+
+* **Access to Old Logs**: A maximum of 10,000 lines of logs from the last 30 days are available for each service. Submit a Support request to access older logs (up to a year old).
+
+* **Additional Instances per Service**: Your subscription plan determines the allowed [`scale` setting](../manage-and-optimize/auto-scaling.md) for your services. By default, all services will have only one additional instance (the Search service must use an odd number of additional instances). The `scale` setting will begin already configured to use the purchased number of instances for your subscription plan.
+
+* **Downtime**: Services running with a single instance may experience restarts when the DXP Cloud infrastructure is updated for scheduled maintenance. Use high availability settings (two instances each of the Web server and Liferay services, and three instances of the Search service) for production-type environments to avoid disruptions. You can view the schedule for planned maintenance [here](https://help.liferay.com/hc/en-us/articles/360032562611-DXP-Cloud-Platform-Maintenance-and-Release-Schedule).
+
+* **Memory per Service Instance**: Services can have up to a possible 200 GB of RAM, and this is determined by your subscription plan. The default plan has 16 GB per service.
+
+## Liferay Service
+
+These limitations apply to the [Liferay service](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md) in each DXP Cloud environment:
+
+* **Remote Staging**: Remote Staging is not available with DXP Cloud. Local Staging is still available and supported.
+
+* **Autoscaling**: When enabled, autoscaling may only add new instances up to a maximum of 10.
+
+### Dynatrace
+
+[Dynatrace](../manage-and-optimize/application-metrics.md#advanced-application-metrics-production-only) is not included in the Standard setup for DXP Cloud environments, but it can be purchased separately to use with it. Dynatrace is included in the High Availability setup, but only for Production or UAT environments.
+
+These limitations apply to Dynatrace:
+
+* **Dynatrace Metrics Discrepancy**: Dynatrace metrics do not match the metrics shown in the DXP Cloud Console. This is because Dynatrace displays metrics for the JVM process, while the console metrics measure the entire container hosting the JVM.
+
+* **Streaming Liferay Logs**: Liferay logs cannot be streamed to Dynatrace logs.
+
+* **Session Replay**: The Dynatrace Session Replay feature is not available with DXP Cloud.
+
+## Database Service
+
+These limitations apply to the [Database service](../platform-services/database-service/database-service.md) in each DXP Cloud environment:
+
+* **Database Metrics**: The metrics displayed in the DXP Cloud console reflect the data for the service container, not individual service metrics.
+
+* **Database Size**: The maximum size for a database is normally 100 GB. This limit can be increased by requesting it from Support.
+
+* **Downtime**: Database maintenance may cause downtime every few months. This downtime usually lasts about two minutes. This may not come with a notification in advance.
+
+## Search Service
+
+These limitations apply to the [Search service](../platform-services/search-service.md) in each DXP Cloud environment:
+
+* **Configuration**: Elasticsearch must be configured through the DXP Cloud workspace, and **not** the Liferay UI. The configuration file in the project workspace is used on each deployment and overwrites the previous configuration.
+
+* **Memory Settings**: The default (and maximum) JVM heap size for the Elasticsearch server is 4 GB. The maximum allocation is determined by your subscription plan.
+
+* **OS Packages**: Installing additional OS packages for the Search service is not supported.
+
+## Backup Service
+
+These limitations apply to the [Backup service](../platform-services/backup-service/backup-service-overview.md) in each DXP Cloud environment:
+
+* **Backup Consistency**: Consistency between data in the database and document library is not guaranteed if a backup is created while the Liferay instance is running.
+
+* **Backup Size**: Before DXP Cloud version 4.2.0, backups used [ephemeral storage](#file-storage). The size of backups in these versions is limited to the remaining space on a shared ephemeral disk, which may vary.
+
+* **Backup Uploads**: Only one backup may be uploaded per minute.
+
+* **Concurrent Operations**: Concurrent backup creation, restores, or uploads or not supported. However, concurrent downloads are supported.
+
+* **Resource Allocation**: The RAM and number of CPUs allocated to the Backup service are determined by your subscription plan. The default allocation is 2 CPUs and 1 GB of RAM for the service.
+
+* **Upload/Download Speed**: The speed of backup uploads or downloads is limited by your internet connection speed and the size of the backup. It may take up to several hours to download a backup with a very slow connection.
+
+## Web Server Service
+
+These limitations apply to the [Web server service](../platform-service/web-server-service.md) in each DXP Cloud environment:
+
+* **Plugins**: Installing additional plugins for the web server is not supported.
+
+* **Resource Allocation**: The web server has 2 vCPUs and 512 MB of memory. This may result in slower response times for large uploads or downloads. This may change depending on your subscription plan.
+
+## Continuous Integration Service
+
+These limitations apply to the [CI service](../platform-services/continuous-integration.md) in each DXP Cloud environment:
+
+* **Administrative access**: Admin-level access is not allowed on the Jenkins server. Instead, use the [Jenkins pipeline hooks](../platform-services/continuous-integration.md#extending-the-default-jenkinsfile) to extend the CI pipeline. Existing DevOps processes may need to be adjusted to conform to this pipeline.
+
+* **Concurrent API Calls**: Projects cannot perform concurrent calls to DXP Cloud API. This includes tasks such as deploying a build to an environment through the [CLI tool](./command-line-tool.md).
+
+* **Resource Allocation**: The RAM and number of CPUs allocated to the CI service are determined by your subscription plan. The default allocation is 4 CPUs and 8 GB of RAM for the service.
+
+* **Server capacity**: Your subscription plan determines the size of the data volume for the CI server.  The default size is 10 GB.
+
+### Builds
+
+These limitations apply to any builds created within a project:
+
+* **Build Size**: Individual builds are limited to 2 GB each. You must ensure that the total size of the project in your repository is less than this limit.
+
+* **Concurrent Builds**: A maximum of two concurrent builds may run on Jenkins because two executor threads are used.
+
+* **Maximum Builds per Day**: Builds are limited to 300 per day. You can request this limit to be increased if needed.
+
+* **Private GitHub Servers**: Integration with private GitHub servers is not supported.
+
+## Custom Services
+
+These limitations apply to any [custom services](../platform-services/using-a-custom-service.md) in a DXP Cloud environment:
+
+* **Host OS Access**: Privileged access to the host Operating System kernel is not allowed, unless you purchase a subscription with a private cluster.
+
+## Security
+
+These limitations apply to the security features available within DXP Cloud:
+
+* **Antivirus**: The default Liferay feature for scanning viruses on file upload cannot be used. DXP Cloud's [Antivirus solution](./dxp-cloud-infrastructure.md#antivirus) is used instead. Uploaded content is scanned on a schedule, and thus risks may not be detected immediately when a file is uploaded.
+
+* **Authentications per Minute**: A maximum of 8400 authentications are allowed per minute.
+
+* **Firewall Rules**: You must purchase a subscription with a private cluster and go through a special support process to set custom firewall rules. Custom firewall rules cannot be used with a shared cluster subscription. Any custom firewall rules created for a private cluster apply to all environments in the project.
+
+* **IP Address Filtering**: IP address filtering can only be applied on the web server service.
+
+## File Storage
+
+These limitations apply to file storage for multiple services:
+
+* **Ephemeral Storage**: Ephemeral Storage is used for all files not stored in volumes. Ephemeral Storage is located on the host node's internal storage, and it is shared between all containers running on that node. If a container requests more space than the host node has available, then the container is moved to another node. The hosts disks have a capacity of 250 GB.
+
+* **Sharing Data Between Services**: Services with the StatefulSet [Deployment Type](../build-and-deploy/understanding-deployment-types.md) cannot share share data with other services.
+
+* **StatefulSet Storage Size**: You must make a Support ticket to add storage for services with the StatefulSet [Deployment Type](../build-and-deploy/understanding-deployment-types.md). The storage size of StatefulSet services cannot be reduced once it is increased.
+
+## Network Configuration
+
+These limitations apply to the network configuration of your services in a DXP Cloud environment:
+
+* **Maximum Custom Domains**: There is a limit of 50 [custom domains](../infrastructure-and-operations/networking/custom-domains.md) if you have multiple services exposed outside of the environment (in addition to the default web server). However, the web server can use a limit of 1500 custom domains.
+
+* **Maximum SSL Certificates**: A maximum of 14 custom SSL certificates are allowed. This may be less depending on the provider issuing the certificates.
+
+* **Public IP Addresses**: By default, every environment has one public IP address, and services within the environment have internal IP addresses. However, you can configure a service's ports to be external, assigning a public IP address to the service.
+
+* **Wildcard SSL Certificates**: Wildcard certificates are not supported for Liferay's auto-generated SSL certificates. However, you may configure your instance with custom Wildcard SSL certificates.
+
+## VPN Servers
+
+These limitations apply if you have connected a [VPN server](../infrastructure-and-operations/networking/vpn-integration-overview.md) to the services in your environment:
+
+**Site-to-Site VPN**: Site-to-Site VPN servers can only be configured with Google Cloud VPN. It also requires a private cluster subscription.
+
+**Bandwidth**: Each VPN tunnel is limited to a total bandwidth of 3 Gbps. This limit applies to the total of incoming and outgoing traffic.
+
+**Extending On-Premises Networks:** Cloud Interconnect or Express Route dedicated connections from an on-premises network are not supported. This applies to connections made directly or via partner providers, and with shared or private clusters.

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-limitations.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-limitations.md
@@ -98,7 +98,7 @@ These limitations apply to the [Backup service](../platform-services/backup-serv
 
 ## Web Server Service
 
-These limitations apply to the [Web server service](../platform-service/web-server-service.md) in each DXP Cloud environment:
+These limitations apply to the [Web server service](../platform-services/web-server-service.md) in each DXP Cloud environment:
 
 * **Plugins**: Installing additional plugins for the web server is not supported.
 

--- a/docs/dxp-cloud/latest/en/reference/platform-limitations.md
+++ b/docs/dxp-cloud/latest/en/reference/platform-limitations.md
@@ -1,16 +1,16 @@
-# DXP Cloud Limitations
+# Platform Limitations
 
-In addition to a collection of features designed to help address development challenges, DXP Cloud also has a number of limitations due to the technologies and underlying infrastructure used to support it. Many of these limitations may vary due to your specific level of subscription. Other limitations may change over time as changes are made to DXP Cloud's infrastructure.
+DXP Cloud and its services have some notable limitations. Many of these limitations may vary due to your specific level of subscription. Other limitations may change over time as changes are made to DXP Cloud's infrastructure.
 
 ## Overview
 
 Take these general limitations into consideration when planning to use DXP Cloud:
 
-* Limits apply on the available CPUs, memory, scaling, network configurations (domains, SSL certificates, and IP addresses), and VPN bandwidth for each service. For instance, each service is limited to a maximum 200 GB RAM, and custom domains are limited to 50 or 1500 depending on your web server's configuration.
+* Limits apply on the available vCPUs, memory, scaling, network configurations (domains, SSL certificates, and IP addresses), and VPN bandwidth for each service. For instance, each service is limited to a maximum 200 GB RAM. Custom domains are also limited to 50 or 1500, depending on your [web server's configuration](#network-configuration).
 
-* Concurrent operations (such as uploads), build size, concurrent builds, and backups also have limitations.
+* Concurrent operations (such as concurrent uploads), build size, concurrent builds, and backups also have limitations.
 
-* Service downtimes will occur (especially for environments with only a single instance of Liferay and Search services) at times for planned maintenance.
+* Service downtime may occur due to planned maintenance, most notably for environments using a single instance of the Liferay or Search services.
 
 * A private cluster subscription may be needed for more stringent security, compliance, or VPN requirements.
 
@@ -27,12 +27,15 @@ See the further sections below for more details.
 * [Continuous Integration Service](#continuous-integration-service)
 * [Custom Services](#custom-services)
 * [Security](#security)
+* [File Storage](#file-storage)
+* [Network Configuration](#network-configuration)
+* [VPN Servers](#vpn-servers)
 
 ## All Services
 
 These limitations apply to every service in a DXP Cloud environment:
 
-* **Access to Old Logs**: A maximum of 10,000 lines of logs from the last 30 days are available for each service. Submit a Support request to access older logs (up to a year old).
+* **Access to Old Logs**: A maximum of 10,000 lines of logs from the last 30 days are available for each service. [Submit a Support request](https://help.liferay.com/) to access older logs (up to a year old).
 
 * **Additional Instances per Service**: Your subscription plan determines the allowed [`scale` setting](../manage-and-optimize/auto-scaling.md) for your services. By default, all services will have only one additional instance (the Search service must use an odd number of additional instances). The `scale` setting will begin already configured to use the purchased number of instances for your subscription plan.
 
@@ -40,11 +43,13 @@ These limitations apply to every service in a DXP Cloud environment:
 
 * **Memory per Service Instance**: Services can have up to a possible 200 GB of RAM, and this is determined by your subscription plan. The default plan has 16 GB per service.
 
+* **Virtual CPUs per Service Instance**: Services can have up to a possible 32 vCPUs, and this is determined by your subscription plan.
+
 ## Liferay Service
 
 These limitations apply to the [Liferay service](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md) in each DXP Cloud environment:
 
-* **Remote Staging**: Remote Staging is not available with DXP Cloud. Local Staging is still available and supported.
+* **Remote Staging**: [Remote Staging](https://learn.liferay.com/dxp/7.x/en/site-building/publishing-tools/staging/configuring-remote-live-staging.html) is not available with DXP Cloud. Local Staging is still available and supported.
 
 * **Autoscaling**: When enabled, autoscaling may only add new instances up to a maximum of 10.
 
@@ -66,7 +71,7 @@ These limitations apply to the [Database service](../platform-services/database-
 
 * **Database Metrics**: The metrics displayed in the DXP Cloud console reflect the data for the service container, not individual service metrics.
 
-* **Database Size**: The maximum size for a database is normally 100 GB. This limit can be increased by requesting it from Support.
+* **Database Size**: The maximum size for a database is normally 100 GB. [Submit a Support request](https://help.liferay.com/) to increase this limit.
 
 * **Downtime**: Database maintenance may cause downtime every few months. This downtime usually lasts about two minutes. This may not come with a notification in advance.
 
@@ -92,7 +97,7 @@ These limitations apply to the [Backup service](../platform-services/backup-serv
 
 * **Concurrent Operations**: Concurrent backup creation, restores, or uploads or not supported. However, concurrent downloads are supported.
 
-* **Resource Allocation**: The RAM and number of CPUs allocated to the Backup service are determined by your subscription plan. The default allocation is 2 CPUs and 1 GB of RAM for the service.
+* **Resource Allocation**: The RAM and number of vCPUs allocated to the Backup service are determined by your subscription plan. The default allocation is 2 vCPUs and 1 GB of RAM for the service.
 
 * **Upload/Download Speed**: The speed of backup uploads or downloads is limited by your internet connection speed and the size of the backup. It may take up to several hours to download a backup with a very slow connection.
 
@@ -102,7 +107,7 @@ These limitations apply to the [Web server service](../platform-services/web-ser
 
 * **Plugins**: Installing additional plugins for the web server is not supported.
 
-* **Resource Allocation**: The web server has 2 vCPUs and 512 MB of memory. This may result in slower response times for large uploads or downloads. This may change depending on your subscription plan.
+* **Resource Allocation**: The web server has 2 vCPUs and 512 MB of memory by default. This may result in slower response times for large uploads or downloads. Your subscription plan determines the specific resource allocation for the service.
 
 ## Continuous Integration Service
 
@@ -110,9 +115,9 @@ These limitations apply to the [CI service](../platform-services/continuous-inte
 
 * **Administrative access**: Admin-level access is not allowed on the Jenkins server. Instead, use the [Jenkins pipeline hooks](../platform-services/continuous-integration.md#extending-the-default-jenkinsfile) to extend the CI pipeline. Existing DevOps processes may need to be adjusted to conform to this pipeline.
 
-* **Concurrent API Calls**: Projects cannot perform concurrent calls to DXP Cloud API. This includes tasks such as deploying a build to an environment through the [CLI tool](./command-line-tool.md).
+* **Concurrent API Calls**: Projects cannot perform concurrent calls to DXP Cloud APIs. This includes tasks such as deploying a build to an environment through the [CLI tool](./command-line-tool.md).
 
-* **Resource Allocation**: The RAM and number of CPUs allocated to the CI service are determined by your subscription plan. The default allocation is 4 CPUs and 8 GB of RAM for the service.
+* **Resource Allocation**: The RAM and number of vCPUs allocated to the CI service are determined by your subscription plan. The default allocation is 4 vCPUs and 8 GB of RAM for the service.
 
 * **Server capacity**: Your subscription plan determines the size of the data volume for the CI server.  The default size is 10 GB.
 
@@ -124,7 +129,7 @@ These limitations apply to any builds created within a project:
 
 * **Concurrent Builds**: A maximum of two concurrent builds may run on Jenkins because two executor threads are used.
 
-* **Maximum Builds per Day**: Builds are limited to 300 per day. You can request this limit to be increased if needed.
+* **Maximum Builds per Day**: Builds are limited to 300 per day. [Submit a Support request](https://help.liferay.com/) to increase this limit.
 
 * **Private GitHub Servers**: Integration with private GitHub servers is not supported.
 
@@ -132,17 +137,17 @@ These limitations apply to any builds created within a project:
 
 These limitations apply to any [custom services](../platform-services/using-a-custom-service.md) in a DXP Cloud environment:
 
-* **Host OS Access**: Privileged access to the host Operating System kernel is not allowed, unless you purchase a subscription with a private cluster.
+* **Host OS Access**: Privileged access to the host Operating System kernel is limited to subscriptions that include a private cluster.
 
 ## Security
 
 These limitations apply to the security features available within DXP Cloud:
 
-* **Antivirus**: The default Liferay feature for scanning viruses on file upload cannot be used. DXP Cloud's [Antivirus solution](./dxp-cloud-infrastructure.md#antivirus) is used instead. Uploaded content is scanned on a schedule, and thus risks may not be detected immediately when a file is uploaded.
+* **Antivirus**: The default Liferay DXP feature for scanning viruses on file upload cannot be used. DXP Cloud's [Antivirus solution](./dxp-cloud-infrastructure.md#antivirus) is used instead. Uploaded content is scanned on a schedule, and thus risks may not be detected immediately when a file is uploaded.
 
 * **Authentications per Minute**: A maximum of 8400 authentications are allowed per minute.
 
-* **Firewall Rules**: You must purchase a subscription with a private cluster and go through a special support process to set custom firewall rules. Custom firewall rules cannot be used with a shared cluster subscription. Any custom firewall rules created for a private cluster apply to all environments in the project.
+* **Firewall Rules**: You must purchase a subscription with a private cluster and coordinate with DXP Cloud Support to set custom firewall rules. Custom firewall rules cannot be used with a shared cluster subscription. Any custom firewall rules created for a private cluster apply to all environments in the project.
 
 * **IP Address Filtering**: IP address filtering can only be applied on the web server service.
 
@@ -152,7 +157,7 @@ These limitations apply to file storage for multiple services:
 
 * **Ephemeral Storage**: Ephemeral Storage is used for all files not stored in volumes. Ephemeral Storage is located on the host node's internal storage, and it is shared between all containers running on that node. If a container requests more space than the host node has available, then the container is moved to another node. The hosts disks have a capacity of 250 GB.
 
-* **Sharing Data Between Services**: Services with the StatefulSet [Deployment Type](../build-and-deploy/understanding-deployment-types.md) cannot share share data with other services.
+* **Sharing Data Between Services**: Services with the StatefulSet [Deployment Type](../build-and-deploy/understanding-deployment-types.md) cannot share data with other services.
 
 * **StatefulSet Storage Size**: You must make a Support ticket to add storage for services with the StatefulSet [Deployment Type](../build-and-deploy/understanding-deployment-types.md). The storage size of StatefulSet services cannot be reduced once it is increased.
 
@@ -160,9 +165,9 @@ These limitations apply to file storage for multiple services:
 
 These limitations apply to the network configuration of your services in a DXP Cloud environment:
 
-* **Maximum Custom Domains**: There is a limit of 50 [custom domains](../infrastructure-and-operations/networking/custom-domains.md) if you have multiple services exposed outside of the environment (in addition to the default web server). However, the web server can use a limit of 1500 custom domains.
+* **Maximum Custom Domains**: There is a limit of 50 [custom domains](../infrastructure-and-operations/networking/custom-domains.md) if you have multiple services exposed outside of the environment (in addition to the default web server). However, the web server can use a limit of 1500 custom domains if it is the only point of entry.
 
-* **Maximum SSL Certificates**: A maximum of 14 custom SSL certificates are allowed. This may be less depending on the provider issuing the certificates.
+* **Maximum SSL Certificates**: A maximum of 14 custom SSL certificates are allowed. The provider issuing the certificates may also impose its own limitations to make this less.
 
 * **Public IP Addresses**: By default, every environment has one public IP address, and services within the environment have internal IP addresses. However, you can configure a service's ports to be external, assigning a public IP address to the service.
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -6,6 +6,8 @@ The Liferay DXP service is the heartbeat of any project. It runs the application
 
 The Liferay DXP service in DXP Cloud can be used in many of the same ways as an on-premise instance of Liferay DXP. However, there are also several differences in configuration and development workflow when working with an instance in DXP Cloud.
 
+See the [Liferay service limitations](../reference/dxp-cloud-limitations.md#liferay-service) for more information.
+
 * [Choosing a Version](#choosing-a-version)
 * [Deployment (Customization, Patching, and Licensing)](#deployment-customization-patching-and-licensing)
 * [Configuration](#configuration)


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9016

This adds a new article detailing the limitations for DXP Cloud, broken down by service (or "component").

Some of my own thoughts on this:

- Went back and forth a fair bit on how fine-grained to make the links from other articles to this article (for example, should the Custom Domains article do this, since there is one limitation pertaining to those? Or the Jenkinsfile hooks breakdown?). In the end I only linked directly to this article from articles that pertained more directly to the major sections, since they could at least have a direct link to their corresponding section (e.g., the service overviews, the VPN overview). I could see this still being valuable to have for those smaller instances too though... or maybe just repeating those single limitations in those other places, too, although that would be maintaining the information in multiple places then
- Also wasn't really coming up with better ideas, but not sure if the bullet-points are overused for formatting here, or if it works okay. I think I got the grouping of limitations a bit better than the source material but not sure I'm quite satisfied with the formatting of it. Would be curious as to your thoughts
- The source material had an introduction that had quite a lot of "marketing-like" material (selling points), I'm guessing to couch the limitations themselves, but I wasn't sure if this would match the style we'd want. So I tried to compromise a bit, though not sure if the introduction is satisfactory as is.

Also as one note, there are some Azure-specific limitations, too. However, we don't have Azure integration itself actually documented, and according to the Cloud team, there are no customers yet using Azure (and it has some issues that possibly are blocking that for now).