### PR TITLE
[DXP Cloud] LRDOCS-9163 Fix note about encryption for customer data in intro

### DIFF
--- a/docs/dxp-cloud/latest/en/getting-started/introduction-to-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/getting-started/introduction-to-dxp-cloud.md
@@ -20,9 +20,11 @@ Every DXP Cloud project comes with:
 
 ## Standards Compliant Security, Automated Backups, and Flexible Governance
 
-DXP Cloud is designed with security in mind. Build and deploy mission-critical sites with confidence knowing that DXP Cloud is **ISO 27001** and **AICPA SOC2** certified. See our [security policy](https://www.liferay.com/documents/10182/3292406/Liferay+DXP+Cloud+Data+Security+and+Protection.pdf/78ce7065-9787-1fb2-9c7b-6d7c13f4a3e6?t=1564674972483) for more information.
+DXP Cloud is designed with security in mind. Build and deploy mission-critical sites with confidence knowing that DXP Cloud is **ISO 27001** and **AICPA SOC2** certified.
 
-[Automated backups](../platform-services/backup-service/backup-service-overview.md) ensure that data and documents are protected and ready for restoration in case of data corruption or failure. Encryption at rest ensures that sensitive data saved on disks isn't readable by any user or application without a valid key.
+All customer data is encrypted at rest by default. Encryption at rest ensures that sensitive data saved on disks isn't readable by any user or application without a valid key. See our [security policy](https://www.liferay.com/documents/10182/3292406/Liferay+DXP+Cloud+Data+Security+and+Protection.pdf/78ce7065-9787-1fb2-9c7b-6d7c13f4a3e6?t=1564674972483) for more information.
+
+[Automated backups](../platform-services/backup-service/backup-service-overview.md) ensure that data and documents are protected and ready for restoration in case of data corruption or failure.
 
 ![Figure 3: DXP Cloud's backup service preserves and protects your data.](./introduction-to-dxp-cloud/images/01.png)
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9163

The introduction to DXP Cloud references encryption for backups, but apparently GCP (underlying infrastructure holding customer data) encrypts all customer data anyway, so it should more clearly state that this applies to all customer data.

Was also noted that more information about encryption keys may be helpful, but this may be contingent upon further information about the available providers (GCP, possibly Azure),which we do not currently have enough information to give with full context.