### PR TITLE
[DXP Cloud] LRDOCS-8919 Auto-scaling: overriding max instances

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -74,9 +74,9 @@ If the `autoscale` property isn't set, the target average utilization defaults t
 
 By default, auto-scaling can increase the number of instances for a service up to 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances.
 
-First, set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed across your services. No services can use more instances than the maximum defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM`.
+Before you can increase the maximum number of instances for any service, you must set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed. Services may not scale beyond the maximum number of instances defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` (10 by default).
 
-Second, specify the desired maximum instances for each service if it needs more than the default 10. In the service's corresponding `LCP.json` file, set the `maxInstances` field within the [`autoscale` object](#specifying-target-average-utilization):
+For each individual service, specify the desired maximum instances if it needs more than the default 10. In the service's corresponding `LCP.json` file, set the `maxInstances` field within the [`autoscale` object](#specifying-target-average-utilization):
 
 ```json
 "autoscale": {

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -72,7 +72,7 @@ If the `autoscale` property isn't set, the target average utilization defaults t
 
 ## Setting the Maximum Number of Instances
 
-The default number of instances that auto-scaling can scale up to is 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances.
+By default, auto-scaling can increase the number of instances for a service up to 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances.
 
 First, set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed across your services. No services can use more instances than the maximum defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM`.
 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -2,7 +2,7 @@
 
 Liferay DXP Cloud's auto-scaling feature automatically creates and destroys instances of the DXP service as needed to optimize performance. This addresses sudden changes such as increased server traffic, memory leaks, or other issues. By default, this feature is *disabled* in every DXP Cloud account.
 
-Using this feature, a service can automatically increase (upscale) the number of Liferay DXP instances to a maximum of 10, or decrease (downscale) to the number specified in the `scale` property in [`LCP.json`](../reference/configuration-via-lcp-json.md). The `scale` property specifies the minimum number of instances to run:
+Using this feature, a service can automatically increase (upscale) the number of Liferay DXP instances to a [defined maximum](#setting-the-maximum-number-of-instances) (10 by default), or decrease (downscale) to the number specified in the `scale` property in [`LCP.json`](../reference/configuration-via-lcp-json.md). The `scale` property specifies the minimum number of instances to run:
 
 ```json
   "scale": 2,
@@ -69,6 +69,22 @@ Specify the target average utilization in the `autoscale` property of the servic
 ```
 
 If the `autoscale` property isn't set, the target average utilization defaults to 80 for both CPU and memory utilization.
+
+## Setting the Maximum Number of Instances
+
+The default number of instances that auto-scaling can scale up to is 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances.
+
+First, set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed across your services. No services can use more instances than the maximum defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM`.
+
+Second, specify the desired maximum instances for each service if it needs more than the default 10. In the service's corresponding `LCP.json` file, set the `maxInstances` field within the [`autoscale` object](#specifying-target-average-utilization):
+
+```json
+"autoscale": {
+    "cpu": 80,
+    "memory": 80,
+    "maxInstances": 15
+}
+```
 
 ## Auto-scaling and DXP Activation Keys
 

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -30,11 +30,10 @@ Files in `/webserver/configs/{ENV}/` will be copied as overrides into /etc/nginx
 
 ## Environment Variables
 
-This service has no environment variables specific to DXP Cloud. All environment 
-variables and other forms of configuration for Nginx are in the 
-[official Nginx documentation](https://docs.nginx.com/). 
-You can set such configurations and environment variables in the `configs/{ENV}/` 
-directory and `LCP.json`, respectively. 
+The `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` environment variable can be used to override the default number of maximum instances for any service (10). If you plan to use [auto-scaling](../manage-and-optimize/auto-scaling.md) for any of your services, then set `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` to the highest value needed for any of these services.
+
+This service has no other environment variables for configuring the Nginx web server. All environment variables and other forms of configuration for Nginx are in the [official Nginx documentation](https://docs.nginx.com/). You can set such configurations and environment variables in the `configs/{ENV}/` 
+directory and `LCP.json`, respectively.
 
 ## Scripts
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-8919

Two settings are now required: an environment variable for the web server service (that must be set to the highest desired value, maximum across all services), and another field (`maxInstances`) in the `autoscale` object in the `LCP.json` for each service's particular maximum.