### PR TITLE
[DXP Cloud] LRDOCS-9233 Update DXP Cloud Service limitation links

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
@@ -6,7 +6,7 @@ Liferay DXP Cloud provides a VPN client-to-site connection that has port forward
 
 Subscribers can use redundant VPN tunnels by mapping their connections between their DXP Cloud services to their corresponding VPN server's IP addresses. The redundancy is placed in different availability zones to provide resiliency. The client-to-site approach covers connecting to a service running on the company network. This model is recommended for the containerized architecture and Kubernetes network layer provided.
 
-See the [VPN server limitations](../../reference/dxp-cloud-limitations.md#vpn-servers) section for more information.
+See the [VPN server limitations](../../reference/platform-limitations.md#vpn-servers) section for more information.
 
 ## Configuration
 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -48,7 +48,7 @@ Users can view allocated resources from the DXP Cloud console.
 
 With Liferay DXP Cloud, you can integrate [Dynatrace's](https://www.dynatrace.com/) advanced performance monitoring with your production environments.
 
-See the [Dynatrace limitations](../reference/dxp-cloud-limitations.md#dynatrace) for more information.
+See the [Dynatrace limitations](../reference/platform-limitations.md#dynatrace) for more information.
 
 ### Integrating Dynatrace with Production Environments
 

--- a/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
+++ b/docs/dxp-cloud/latest/en/platform-services/continuous-integration.md
@@ -12,7 +12,7 @@ By default, this automated build will compile code and can be configured to exec
    Continuous integration only works if you deploy from GitHub, GitLab, or Bitbucket, not the CLI.
 ```
 
-See the [CI service limitations](../reference/dxp-cloud-limitations.md#continuous-integration-service) for more information.
+See the [CI service limitations](../reference/platform-limitations.md#continuous-integration-service) for more information.
 
 ## Using the Default Jenkinsfile
 

--- a/docs/dxp-cloud/latest/en/platform-services/database-service/database-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/database-service/database-service.md
@@ -4,7 +4,7 @@ The database service (MySQL) is a distributed relational database service that s
 
 ![Figure 1: The database service is one of several services available in DXP Cloud.](./database-service/images/01.png)
 
-See the [Database service limitations](../../reference/dxp-cloud-limitations.md#database-service) section for more information.
+See the [Database service limitations](../../reference/platform-limitations.md#database-service) section for more information.
 
 ## Environment Variables
 
@@ -34,5 +34,5 @@ Name                                   | Acceptable Value | Default Value |
 
 * [Changing Your Database Username](./changing-your-database-username.md)
 * [Changing Your Database Password](./changing-your-database-password.md)
-* [Database Service Limitations](../../reference/dxp-cloud-limitations.md#database-service)
+* [Database Service Limitations](../../reference/platform-limitations.md#database-service)
 * [Using the MySQL Client](../../using-the-liferay-dxp-service/using-the-mysql-client.md)

--- a/docs/dxp-cloud/latest/en/platform-services/search-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/search-service.md
@@ -6,7 +6,7 @@ services in your application, not with the outside internet.
 
 ![Figure 1: The Elasticsearch service is one of several services available in DXP Cloud.](./search-service/images/01.png)
 
-See the [Search service limitations](../reference/dxp-cloud-limitations.md#search-service) section for more information.
+See the [Search service limitations](../reference/platform-limitations.md#search-service) section for more information.
 
 ## Configurations
 

--- a/docs/dxp-cloud/latest/en/platform-services/using-a-custom-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/using-a-custom-service.md
@@ -8,7 +8,7 @@ DXP Cloud allows you to run more than just the standard set of services provided
 
 DXP Cloud uses Docker images as the basis for its services. If you want to run these services locally, [install Docker](https://docs.docker.com/get-docker/) on your local system.
 
-See the [custom services limitations](../reference/dxp-cloud-limitations.md#custom-services) for more information.
+See the [custom services limitations](../reference/platform-limitations.md#custom-services) for more information.
 
 ## Adding a Custom Service
 

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -6,7 +6,7 @@ high-performance web server.
 
 ![Figure 1: The web server is one of several services available in DXP Cloud.](./web-server-service/images/01.png)
 
-See the [Web server service limitations](../dxp-cloud-limitations.md#web-server-service) section for more information.
+See the [Web server service limitations](../platform-limitations.md#web-server-service) section for more information.
 
 ## Configurations
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md
@@ -6,7 +6,7 @@ The Liferay DXP service is the heartbeat of any project. It runs the application
 
 The Liferay DXP service in DXP Cloud can be used in many of the same ways as an on-premise instance of Liferay DXP. However, there are also several differences in configuration and development workflow when working with an instance in DXP Cloud.
 
-See the [Liferay service limitations](../reference/dxp-cloud-limitations.md#liferay-service) for more information.
+See the [Liferay service limitations](../reference/platform-limitations.md#liferay-service) for more information.
 
 * [Choosing a Version](#choosing-a-version)
 * [Deployment (Customization, Patching, and Licensing)](#deployment-customization-patching-and-licensing)


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9233

Originally from @ZoltanTakacs at: https://github.com/liferay/liferay-learn/pull/150

It seems the `DXP Cloud Limitations` article was too hastily renamed before it was merged (I most likely forgot to check) and a ton of links were still broken. I can at least confirm that with this PR there are no more references to the old/incorrect name.