### PR TITLE
[DXP Cloud] LRDOCS-9274 Correct auto-scaling information to specifically reference Liferay service

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/auto-scaling.md
@@ -72,19 +72,21 @@ If the `autoscale` property isn't set, the target average utilization defaults t
 
 ## Setting the Maximum Number of Instances
 
-By default, auto-scaling can increase the number of instances for a service up to 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances.
+By default, auto-scaling can increase the number of instances for the `liferay` service up to 10. However, you can override this default to use more instances if necessary. You must override the default in two places to allow services to use more than the default 10 instances:
 
-Before you can increase the maximum number of instances for any service, you set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed. Services may not scale beyond the maximum number of instances defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` (10 by default).
+1. Set the `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` [environment variable](../reference/defining-environment-variables.md) in your [web server service](../platform-services/web-server-service.md) to the highest value needed. The `liferay` service may not scale beyond the maximum number of instances defined in `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` (10 by default).
 
-For each individual service, specify the desired maximum instances if it needs more than the default 10. In the service's corresponding `LCP.json` file, set the `maxInstances` field within the [`autoscale` object](#specifying-target-average-utilization):
+1. Within the `liferay` service's `LCP.json` file, specify the desired maximum instances if it needs more than the default 10. Set the `maxInstances` field within the [`autoscale` object](#specifying-target-average-utilization):
 
-```json
-"autoscale": {
-    "cpu": 80,
-    "memory": 80,
-    "maxInstances": 15
-}
-```
+    ```json
+    "autoscale": {
+        "cpu": 80,
+        "memory": 80,
+        "maxInstances": 15
+    }
+    ```
+
+Once you have updated both of these configurations, then auto-scaling can your `liferay` service's instances up to your newly defined maximum.
 
 ## Auto-scaling and DXP Activation Keys
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9274

Per feedback from the Cloud team, the new information for increasing the max instances for auto-scaling is misleading because it implies services other than the `liferay` service can use auto-scaling, which is not meant to be the case. This fixes that.

Also, this changes my understanding of the purpose of setting the `web server` environment variable (i.e., it effectively is still the "maximum" across services, but there is only one service that maximum may apply to, so it is a one-to-one relationship and not a one-to-many). I think that then renders my earlier point to you @jrhoun moot as to why they shouldn't be numbered, since it seems you actually should be able to always do them together. I numbered the locations to reflect this.