### PR TITLE
[DXP Cloud] LRDOCS-9271 Dynatrace updates

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -76,8 +76,10 @@ Follow these steps to integrate Dynatrace:
 
 | Name | Description |
 | --- | --- |
-`LCP_PROJECT_MONITOR_DYNATRACE_TENANT` | A string with eight characters. It is part of the URL (prefix) of your Dynatrace SaaS account. |
-`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` | A string with 22 characters that you can find in your Dynatrace account at *Deploy Dynatrace* &rarr; *Start installation* &rarr; *Set up PaaS monitoring* &rarr; *Installer Download*. |
+`LCP_PROJECT_MONITOR_DYNATRACE_TENANT` | A string of characters that is part of the URL (prefix) of your Dynatrace SaaS account. |
+`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` | A string of characters that you can find in your Dynatrace account at *Deploy Dynatrace* &rarr; *Start installation* &rarr; *Set up PaaS monitoring* &rarr; *Installer Download*. |
+
+See the [official Dynatrace documentation](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/) for more information about these values.
 
 ### Accessing Dynatrace
 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -58,15 +58,16 @@ Follow these steps to integrate Dynatrace:
 
 1. Generate the Dynatrace secret `token` and `tenant` values.
 
-1. Add Dynatrace environment variables to the `LCP.json` file in the Liferay service's production environment. For example:
+1. Add the Dynatrace `token` value as a [Secret](../infrastructure-and-operations/security/managing-secure-environment-variables-with-secrets.md) for the Liferay service.
+
+1. Add the Dynatrace `tenant` Dynatrace environment variables to the `LCP.json` file in the Liferay service's production environment. For example:
 
 ```json
 {
 	"environments": {
 	  "prd": {
 	    "env": {
-	      "LCP_PROJECT_MONITOR_DYNATRACE_TENANT": "tot02934",
-	      "LCP_PROJECT_MONITOR_DYNATRACE_TOKEN": "dDKSowkdID8dKDkCkepW"
+	      "LCP_PROJECT_MONITOR_DYNATRACE_TENANT": "tot02934"
 	    }
 	  }
 	}

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/liferay-service-environment-variables.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/liferay-service-environment-variables.md
@@ -46,14 +46,14 @@ Name                                  | Default Value | Description  |
 `LCP_LIFERAY_JDBC_CONNECTION_URL` |  | The URL used to make the database connection. This may be used to directly set the database name and host. The value should start with `jdbc:mysql://`. |
 `LCP_LIFERAY_JDBC_DRIVER` |  | Allows for specifying the MySQL driver the Liferay service uses. In DXP versions 7.0 and 7.1, this is also used for the cluster configuration. |
 `LCP_PROJECT_LIFERAY_CLUSTER_ENABLED` | `true` | Whether to enable clustering and communication between nodes. |
-`LCP_PROJECT_MONITOR_DYNATRACE_TENANT` |  | A string with eight characters. It's part of the URL (prefix) of your Dynatrace SaaS account. |
-`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` |  | A string with 22 characters that you can find in your Dynatrace account at *Deploy Dynatrace* &rarr; *Start installation* &rarr; *Set up PaaS monitoring* &rarr; *Installer Download*. |
+`LCP_PROJECT_MONITOR_DYNATRACE_TENANT` |  | A string of characters that is part of the URL (prefix) of your Dynatrace SaaS account. Use this together with the `LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` secret. |
 `LIFERAY_JAVA_OPTS` | | JVM options that will be appended to `CATALINA_OPTS` to override the default recommended options. |
 
 These variables must instead be [defined as Secrets](../infrastructure-and-operations/security/managing-secure-environment-variables-with-secrets.md) for the Liferay service:
 
 Name                                  | Default Value | Description  |
 ------------------------------------- | ------------- | ------------ |
+`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` |  | A string of characters that you can find in your Dynatrace account at *Deploy Dynatrace* &rarr; *Start installation* &rarr; *Set up PaaS monitoring* &rarr; *Installer Download*. |
 `LCP_SECRET_DATABASE_NAME` |   | The database name used for database connections (jdbc, jdbc ping, and read-only user connections). |
 `LCP_SECRET_DATABASE_PASSWORD` |  |  The database password used only for the jdbc (and jdbc ping) configurations. |
 `LCP_SECRET_DATABASE_READONLY_USER` |  | The read-only user's username. |


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9271

This addresses two updates asked by the Cloud team (specifically from engineering):

* Have customers use Secrets for the token value rather than a regular environment variable
* Avoid directly referencing the token size, since that is determined by Dynatrace and could change. Point to Dynatrace documentation instead