### PR TITLE
[DXP Cloud] LRDOCS-9317 The 'certs' property

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/custom-domains.md
@@ -50,6 +50,10 @@ Follow these steps to add custom domains to environment services via the DXP Clo
 
 1. Click *Update Custom Domains* to finalize the addition.
 
+```note::
+   Adding custom domains via the DXP Cloud console automatically uses a certificate provided by `Let's Encrypt <https://letsencrypt.org/>`__ for all of them. If you want to use `custom SSL certificates <./load-balancer.md#custom-ssl>`__ for your custom domains, then you must add them via the web server's ``LCP.json`` file instead.
+```
+
 ### Adding a Custom Domain via LCP.json
 
 Alternatively, you can replace the domains that an environment's service uses by adding the `customDomains` property to its `LCP.json` file. Add the property within an `environments` attribute for the specific environment:
@@ -97,7 +101,7 @@ It may take some time to be able to verify a custom domain after configuration d
 
 Once backend processes are complete, DXP Cloud's load balancer is updated with the SSL server certificate, and the service is reachable and secure.
 
-See [Load Balancer](./load-balancer.md) to learn more about SSL certificates in Liferay DXP Cloud, including how to set up a custom SSL certificate.
+See [Load Balancer](./load-balancer.md) to learn more about SSL certificates in Liferay DXP Cloud, including how to set up one or more custom SSL certificates.
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/load-balancer.md
@@ -55,22 +55,57 @@ Domains created by DXP Cloud's infrastructure at `.lfr.cloud` are covered by a w
 
 For all custom domains added through the console or `LCP.json`, Liferay DXP Cloud reaches out to [Let's Encrypt](https://letsencrypt.org/) for a certificate that renews automatically and covers all custom domains you create.
 
-### Custom SSL Certificates
+### Adding Custom SSL Certificates
 
-You can also add your own SSL certificate to cover any custom domains you create. However, only one certificate can be used at a time for a service's custom domains: either the one provided by Let's Encrypt, or the custom one specified in its `LCP.json`. If both certificates exist, the custom certificate takes precedent.
+You can also add your own SSL certificate to cover any custom domains you create. You can either use the SSL certificate provided by Let's Encrypt (for any custom domains added through the DXP Cloud console), or you can define one or more custom certificates in your `webserver` service's `LCP.json` file. If certificates exist in both places, then any custom certificates defined in the `LCP.json` file take precedent.
 
-When creating custom certificates, note that DXP Cloud only accepts keys and certificates that are in the proper PEM format with [Base64](https://tools.ietf.org/html/rfc4648#section-4) encoding, which must include encapsulation boundaries:
+When creating custom certificates, note that DXP Cloud only accepts keys and certificates that are in the proper PEM format with [Base64](https://tools.ietf.org/html/rfc4648#section-4) encoding, which must include encapsulation boundaries.
+
+To add a single SSL certificate to the `LCP.json` file, add an `ssl` object with certificates `key` and `crt` values inside of the [`loadbalancer` object](./custom-domains.md#adding-a-custom-domain-via-lcp-json):
 
 ```json
-"ssl": {
-  "key": "...",
-  "crt": "..."
+{
+    "loadbalancer": {
+        "ssl": {
+            "key": "...",
+            "crt": "..."
+        }
+    }
 }
 ```
 
-```important::
-   The ``ssl`` property (containing the ``key`` and ``crt`` properties) must be contained within the ``loadbalancer`` property to work properly.
+Using the `ssl` object in your `LCP.json` creates a single custom SSL certificate that maps to all custom domains used in this environment.
+
+### Mapping Multiple SSL Certificates to Custom Domains
+
+You can also map different SSL certificates to multiple custom domains by using the `certs` property instead of the `ssl` object.
+
+Use the `certs` property in your web server's `LCP.json` file to create a list of certificates that you can use. Group the `key` and `crt` values for each certificate together with the custom domains they will map to:
+
+```json
+{
+    "loadbalancer": {
+        "certs": [
+            {
+                "customDomains": ["acme.liferay.cloud"],
+                "key": "...",
+                "crt": "..."
+            },
+            {
+                "customDomains": ["acme2.liferay.cloud"],
+                "key": "...",
+                "crt": "..."
+            }
+        ]
+    }
+}
 ```
+
+```note::
+   Mapping multiple SSL certificates to your custom domains requires adding the ``certs`` property to the ``webserver`` service's ``LCP.json`` file. Adding custom domains through the DXP Cloud console instead maps all of the custom domains to a single certificate.
+```
+
+### Generating an SSL Certificate
 
 When generating a key, you must use either RSA-2048 or ECDSA P-256 encryption algorithms and avoid using passphrase protected keys.
 
@@ -131,8 +166,8 @@ The Network page shows any custom certificates, with a maximum of one per servic
 | `cdn` | false | CDN is disabled by default; can be enabled by setting to `true` |
 | `customDomains` | ["example.com", "www.example.com"] | Name of the custom domain; can list more than one |
 | `targetPort` | 3000 | Port number for the load balancer |
-| `key` | | SSL certificate's key in Base64 format |
-| `crt` | | SSL certificate's crt in Base64 format |
+| `key` | | SSL certificate's key in Base64 format. Group this in an [`ssl`](#adding-custom-ssl-certificates) object, or a [`certs`](#mapping-multiple-ssl-certificates-to-custom-domains) object (to list multiple certificates). |
+| `crt` | | SSL certificate's crt in Base64 format. Group this in an [`ssl`](#adding-custom-ssl-certificates) object, or a [`certs`](#mapping-multiple-ssl-certificates-to-custom-domains) object (to list multiple certificates). |
 
 ## Additional Information
 

--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -34,8 +34,9 @@ Files in `/webserver/configs/{ENV}/` will be copied as overrides into /etc/nginx
 
 The `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` environment variable can be used to override the default number of maximum instances for any service (10). If you plan to use [auto-scaling](../manage-and-optimize/auto-scaling.md) for any of your services, then set `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` to the highest value needed for any of these services.
 
-This service has no other environment variables for configuring the Nginx web server. All environment variables and other forms of configuration for Nginx are in the [official Nginx documentation](https://docs.nginx.com/). You can set such configurations and environment variables in the `configs/{ENV}/` 
-directory and `LCP.json`, respectively.
+The [Ingress Load Balancer](../infrastructure-and-operations/networking/load-balancer.md) is also configured via the web server service. Environment variables can be added to this service to configure the load balancer and custom domains. See [the Load Balancer environment variables reference](../infrastructure-and-operations/networking/load-balancer.md#environment-variables-reference) for more information.
+
+This service has no other environment variables for configuring the Nginx web server. All environment variables and other forms of configuration for Nginx are in the [official Nginx documentation](https://docs.nginx.com/). You can set such configurations in the `configs/{ENV}/` directory, environment variables in the service's `LCP.json` file.
 
 ## Scripts
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9317

This documents how to map multiple SSL certificates to custom domains by using the `certs` object in `LCP.json`. There are plans to add a method to do this in the UI, but for now this can only be achieved through `LCP.json` configuration.

Please let me know of any thoughts/concerns you may have with this. Thanks.