### PR TITLE
Fixes some broken links in AC documentation

### DIFF
--- a/docs/analytics-cloud/latest/en/connecting-data-sources/managing-data-sources.md
+++ b/docs/analytics-cloud/latest/en/connecting-data-sources/managing-data-sources.md
@@ -21,8 +21,8 @@ The Data Sources page appears and lists all existing data sources.
 Unless a teammate has already added a data source, the list is empty. To add a new data source, see the following tutorials:
 
 * [Adding a Liferay DXP Data Source](./connecting-liferay-dxp-to-analytics-cloud.md)
-* [Adding a CSV Data Source](../../people/individuals/adding-a-csv-data-source.md)
-* [Adding a Salesforce Data Source](../../people/individuals/adding-a-salesforce-data-source.md)
+* [Adding a CSV Data Source](../people/individuals/adding-a-csv-data-source.md)
+* [Adding a Salesforce Data Source](../people/individuals/adding-a-salesforce-data-source.md)
 
 Once you’ve created your data sources, you might need to modify them from time to time.
 
@@ -31,7 +31,7 @@ Once you’ve created your data sources, you might need to modify them from time
 The Data Sources page shows all of the Data Sources added to Analytics Cloud and can be searched by keyword. You can edit data sources in the following ways:
 
 * Name of the data source
-* [Contact mapping](../../people/individuals/adding-a-csv-data-source.md#mapping-contact-data)
+* [Contact mapping](../people/individuals/adding-a-csv-data-source.md#mapping-contact-data)
 * Enable/Disable Contact or Analytics sync
 
 Here’s how to delete a data source:

--- a/docs/analytics-cloud/latest/en/getting-started/viewing-the-analytics-dashboard.md
+++ b/docs/analytics-cloud/latest/en/getting-started/viewing-the-analytics-dashboard.md
@@ -8,13 +8,13 @@ The Dashboard is also the starting point for a variety of workspace management a
 
 ## Connecting a DXP Site to Analytics Cloud
 
-The first task for a new workspace is to connect it to a Data Source. Analytics Cloud is built to use Liferay DXP Sites as a key data source. See [Connecting Liferay DXP Sites to Analytics Cloud](../connecting-data-sources/connecting-liferay-dxp-to-analytics-cloud.md) to learn more. You can also bring in data from [CSV files](../../people/individuals/adding-a-csv-data-source.md) and [Salesforce](../../people/individuals/adding-a-salesforce-data-source.md) to supplement your existing user data.
+The first task for a new workspace is to connect it to a Data Source. Analytics Cloud is built to use Liferay DXP Sites as a key data source. See [Connecting Liferay DXP Sites to Analytics Cloud](../connecting-data-sources/connecting-liferay-dxp-to-analytics-cloud.md) to learn more. You can also bring in data from [CSV files](../people/individuals/adding-a-csv-data-source.md) and [Salesforce](../people/individuals/adding-a-salesforce-data-source.md) to supplement your existing user data.
 
 ## Inviting Others to Your Workspace
 
 As a workspace owner or admin, you can invite your colleagues to the workspace. Invited users can be configured to help setup and configure data sources, create segments, or simply view analytics reports.
 
-See [Managing Users](../../workspace-settings/managing-users.md) to learn more about adding users to your workspace.
+See [Managing Users](../workspace-settings/managing-users.md) to learn more about adding users to your workspace.
 
 ## Configure Settings for Your Workspace
 
@@ -26,4 +26,4 @@ Most of the important settings are configured when you created the workspace. Ho
 * Workspace Usage Monitoring
 * Workspace Settings
 
-You will begin to see analytics data once your workspace is connected. For example, view Site specific analytics on the [Sites dashboard](../../touchpoints/sites-dashboard.md). To see more about your workspace settings, see [Managing Workspaces](../../workspace-settings/managing-workspaces.md). 
+You will begin to see analytics data once your workspace is connected. For example, view Site specific analytics on the [Sites dashboard](../touchpoints/sites-dashboard.md). To see more about your workspace settings, see [Managing Workspaces](../workspace-settings/managing-workspaces.md). 

--- a/docs/analytics-cloud/latest/en/people/accounts.md
+++ b/docs/analytics-cloud/latest/en/people/accounts.md
@@ -44,7 +44,7 @@ The Activities tab shows the activities of the individuals in the account. A his
 
 ## Interests
 
-The Interests tab shows the topics of interest for the account’s individuals. Analytics Cloud identifies these topics via the same methodology it uses for individuals. For more information, see [Understanding Interests](../../workspace-data/managing-interest-topics.md#understanding-interests).
+The Interests tab shows the topics of interest for the account’s individuals. Analytics Cloud identifies these topics via the same methodology it uses for individuals. For more information, see [Understanding Interests](../workspace-data/managing-interest-topics.md#understanding-interests).
 
 ## Segments
 


### PR DESCRIPTION
Quick fix: I was looking through documentation on Salesforce when I noticed a few broken links in AC, so I just fixed them.