### PR TITLE
[DXP Cloud] LRDOCS-9374 Document LCP_WEBSERVER_LOG_FORMAT property

### DIFF
--- a/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
+++ b/docs/dxp-cloud/latest/en/platform-services/web-server-service.md
@@ -32,11 +32,16 @@ Files in `/webserver/configs/{ENV}/` will be copied as overrides into /etc/nginx
 
 ## Environment Variables
 
-The `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` environment variable can be used to override the default number of maximum instances for any service (10). If you plan to use [auto-scaling](../manage-and-optimize/auto-scaling.md) for any of your services, then set `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` to the highest value needed for any of these services.
+These environment variables are available for the web server service:
+
+| Name | Default value | Description |
+| --- | --- | --- |
+| `LCP_HAPROXY_SERVER_TEMPLATE_BACKEND_NUM` | `10` | Overrides the maximum number of instances for any service. If you plan to use [auto-scaling](../manage-and-optimize/auto-scaling.md), then set this to the highest value needed. |
+| `LCP_WEBSERVER_LOG_FORMAT` |   | Customizes the format for Nginx logging. See the [official Nginx documentation](https://docs.nginx.com/nginx/admin-guide/monitoring/logging/#setting-up-the-access-log). |
 
 The [Ingress Load Balancer](../infrastructure-and-operations/networking/load-balancer.md) is also configured via the web server service. Environment variables can be added to this service to configure the load balancer and custom domains. See [the Load Balancer environment variables reference](../infrastructure-and-operations/networking/load-balancer.md#environment-variables-reference) for more information.
 
-This service has no other environment variables for configuring the Nginx web server. All environment variables and other forms of configuration for Nginx are in the [official Nginx documentation](https://docs.nginx.com/). You can set such configurations in the `configs/{ENV}/` directory, environment variables in the service's `LCP.json` file.
+All environment variables and other forms of configuration for Nginx are in the [official Nginx documentation](https://docs.nginx.com/). You can set such configurations in the `configs/{ENV}/` directory, and environment variables in the service's `LCP.json` file.
 
 ## Scripts
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9374

The new `LCP_WEBSERVER_LOG_FORMAT` environment variable is used to set the Nginx configuration for how the logs are printed. There is a lot of flexibility with this, but it is explained in the official Nginx docs (and is an Nginx behavior), so it's simplest to just point to those.

I also took the liberty of reorganizing the `webserver` env vars into a table since there are now multiple of them, and more may be added with time. Let me know if there are any thoughts or concerns on this. Thanks.