### PR TITLE
[DXP Cloud] LRDOCS-9541 Document Session Replication limitation

### DIFF
--- a/docs/dxp-cloud/latest/en/reference/platform-limitations.md
+++ b/docs/dxp-cloud/latest/en/reference/platform-limitations.md
@@ -53,6 +53,8 @@ These limitations apply to the [Liferay service](../using-the-liferay-dxp-servic
 
 * **Autoscaling**: When enabled, autoscaling may only add new instances up to a maximum of 10.
 
+* **Session Replication**: Replicating sessions between multiple Liferay instances in DXP Cloud may impact your instances' performance, and it is not supported. Instead, make use of sticky sessions, or avoid using session storage entirely in your custom applications.
+
 ### Dynatrace
 
 [Dynatrace](../manage-and-optimize/application-metrics.md#advanced-application-metrics-production-only) is not included in the Standard setup for DXP Cloud environments, but it can be purchased separately to use with it. Dynatrace is included in the High Availability setup, but only for Production or UAT environments.


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9541

Quick request came up to document this as a limitation (and the best practice for this purpose). It would be nice if we could also link to an explanation of session storage or sticky sessions in Liferay, but we do not have a Liferay-specific reference for this on Learn as of yet.