### PR TITLE
[DXP Cloud] LRDOCS-9535 Update references to backups

### DIFF
--- a/docs/dxp-cloud/latest/en/getting-started/understanding-dxp-cloud-environments.md
+++ b/docs/dxp-cloud/latest/en/getting-started/understanding-dxp-cloud-environments.md
@@ -31,12 +31,12 @@ Besides having different prices and computing power, these environment types dif
 
 **Production**
 
-* Backup: Data can be backed up and restored into any environment.
+* Backup: Data backups are automatically created on a regular schedule by default.
 * Database: Data is replicated in multiple availability zones and contains enhanced IOPS.
 
 **Non-production**
 
-* Backup: Data can only be restored to these environments.
+* Backup: Data backups are not created automatically by default.
 * Database: Data is present in a single availability zone and contains regular IOPS.
 
 ![Figure 3: Your environment's type appears in Settings.](./understanding-dxp-cloud-environments/images/03.png)

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
@@ -4,7 +4,7 @@ Maintaining regular backups is vital to protecting your project's data. The DXP 
 
 ![The backup service is one of several services available in DXP Cloud.](./backup-service-overview/images/01.png)
 
-From the Backups page in `prd` environments, you can create backups, view or download retained backups, and restore an environment from a backup.
+From the Backups page in any environment, you can create backups, view or download retained backups, and restore an environment from a backup.
 
 You can also configure the backup service to meet your project's needs via the DXP Cloud console or the backup service's `LCP.json` file.
 
@@ -12,25 +12,23 @@ See the [Backup service limitations](../../reference/platform-limitations.md#bac
 
 ## The Backups Page
 
-From the Backups page in `prd` environments, you can view backup service information and retained backups, create manual backups, and more.
+From the Backups page in any environment, you can view backup service information and retained backups, create manual backups, and more.
 
 ```note::
-   The Backups page is only available in production environments.
+   The Backups page is only available in production environments for backup service versions older than 4.3.5.
 ```
 
 Follow these steps to access the Backups page:
 
-1. Navigate to your project's `prd` environment.
+1. Click on *Backups* in the menu on the left from any environment.
 
-1. Click on *Backups* in the environment menu.
-
-![View backup history, create manual backups, and more from the Backups page in prd environments.](./backup-service-overview/images/02.png)
+![View backup history, create manual backups, and more from the Backups page in any environment.](./backup-service-overview/images/02.png)
 
 From here, you can perform the following tasks:
 
-* **View Backup Info**: You can quickly view backup service information for the `prd` environment. This includes the frequency of automated backups, the backup retention period, and timestamp information for the next scheduled backup, the latest created backup, and the oldest retained backup.
-* **View Backup History**: You can view the full list of retained backups in the `prd` environment. Each entry lists the backup's name, size, and time of creation.
-* **Create Manual Backups**: You can manually create a backup of the `prd` environment. See [Creating a Manual Backup](#creating-a-manual-backup) for more information.
+* **View Backup Info**: You can quickly view backup service information for the chosen environment. This includes the frequency of automated backups, the backup retention period, and timestamp information for the next scheduled backup, the latest created backup, and the oldest retained backup.
+* **View Backup History**: You can view the full list of retained backups in the chosen environment. Each entry lists the backup's name, size, and time of creation.
+* **Create Manual Backups**: You can manually create a backup of the chosen environment. See [Creating a Manual Backup](#creating-a-manual-backup) for more information.
 
 ```note::
    Backup timestamps are displayed automatically based on your browser location, while backup schedules are based on the UTC±00 time zone.
@@ -40,11 +38,11 @@ From the Backups page, environment administrators also have access to the Action
 
 For more information and instructions on how to perform these actions, see [Downloading and Uploading Backups](./downloading-and-uploading-backups.md) and [Restoring Data from a Backup](./restoring-data-from-a-backup.md).
 
-![Production environment administrators can download backups or restore an environment from the Backups page.](./backup-service-overview/images/03.png)
+![Administrators can download backups or restore an environment from the Backups page.](./backup-service-overview/images/03.png)
 
 ## Creating a Manual Backup
 
-To manually backup your `prd` environment from the Backups page, click on *Backup Now*. This process can take several minutes or hours depending on the size of your services.
+To manually backup your environment from the Backups page, click on *Backup Now*. This process can take several minutes or hours depending on the size of your services.
 
 Once started, the backup service icon will indicate a backup is in progress, and a new backup will appear in the *Backup history*.
 
@@ -80,9 +78,9 @@ Follow these steps to configure the backup service via the DXP Cloud Console:
 
 1. Click on the *Environment Variables* tab.
 
-   ![Navigate to the backup service's variables tab in your production environment.](./backup-service-overview/images/05.png)
+   ![Navigate to the backup service's variables tab in your environment.](./backup-service-overview/images/05.png)
 
-   You can also access the backup service's page by clicking on *Backup* in the environment *Overview* page.
+   You can also access the backup service's page by clicking on *Backup* in the environment's *Overview* page.
 
 1. Add variables from the [Environment Variables Reference](#environment-variables-reference) list to configure the backup service.
 
@@ -124,7 +122,7 @@ Determining how frequently backups are created and removed can help protect your
    Backups created while data is actively changing on your Liferay instance risk creating inconsistent data. Configure your backup schedule to create backups during times with reduced activity to mitigate the risk of data inconsistency. To ensure a completely consistent backup, coordinate with your database administrator to freeze updates while you perform a `manual backup <./backup-service-overview.md#creating-a-manual-backup>`__.
 ```
 
-Use the following variables to customize when backups are created and removed:
+Use the following variables per environment to customize when backups are created and removed:
 
 * **Automated Backups**: Add the `LCP_BACKUP_CREATE_SCHEDULE` variable with a [cron scheduling](https://crontab.guru/) value to set the frequency of automated backups.
 * **Automated Cleanups**: Add the `LCP_BACKUP_CLEANUP_SCHEDULE` variable with a [cron scheduling](https://crontab.guru/) value to set the frequency of automated backup cleanups.

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service/downloading-and-uploading-backups.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service/downloading-and-uploading-backups.md
@@ -4,9 +4,13 @@ The DXP Cloud backup service creates backups of an environment's database and th
 
 Users can also download or upload environment backups [using the DXP Cloud Console](#uploading-backups-via-the-console), or through [Backup APIs](#backup-service-apis).
 
+```note::
+   The Backups page is only available in production environments for backup service versions older than 4.3.5.
+```
+
 ## Downloading Backups via the Console
 
-Follow these steps to download a backup from the *Backups* page in your `prd` environment:
+Follow these steps to download a backup from the *Backups* page in your chosen environment:
 
 1. Click on the *Actions* button ( ⋮ ) for the backup you want to download.
 
@@ -23,12 +27,12 @@ Follow these steps to download a backup from the *Backups* page in your `prd` en
     ![Click to download the database and Liferay data volume files.](./downloading-and-uploading-backups/images/02.png)
 
 ```note::
-   Only production environment administrators can download backups from the Backups page.
+   Only administrators for the chosen environment can download backups from the Backups page.
 ```
 
 ## Uploading Backups via the Console
 
-You can also upload a backup to your project through the *Backups* page in your `prd` environment.
+You can also upload a backup to your project through the *Backups* page in your chosen environment.
 
 Before you can upload a backup to DXP Cloud, you must compress the database dump and document library in separate archives. See [Preparing the Database and Document Library for Upload](#preparing-the-database-and-document-library-for-upload) for more information on preparing for the upload for an on-premises environment.
 
@@ -40,7 +44,7 @@ Follow these steps from the *Backups* page:
 
 1. Click *Upload Backup...* near the top of the screen.
 
-1. On the Upload Backup page, expand the appropriate production environment, and then click the `+` icons for both the database and document library to upload them.
+1. On the Upload Backup page, expand the appropriate environment, and then click the `+` icons for both the database and document library to upload them.
 
     ![Click the icons to upload both the database and document library as .gz archives.](./downloading-and-uploading-backups/images/03.png)
 
@@ -81,7 +85,7 @@ Here's an example that uses token authentication with the upload API:
 
 ```bash
 curl -X POST \
-  https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/upload \
+  https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
   -H 'dxpcloud-authorization: Bearer <USER_TOKEN>' \
   -F 'database=@/my-folder/database.gz' \
@@ -106,7 +110,7 @@ Name | Type     | Required |
 
 ```bash
 curl -X GET \
-  https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/download/database/id \
+  https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/download/database/id \
   -u user@domain.com:password \
   --output database.gz
 ```
@@ -129,7 +133,7 @@ Name | Type     | Required |
 
 ```bash
 curl -X GET \
-  https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/download/volume/id \
+  https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/download/volume/id \
   -u user@domain.com:password \
   --output volume.tgz
 ```
@@ -159,7 +163,7 @@ Name       | Type   | Required |
 
 ```bash
 curl -X POST \
-  https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/upload \
+  https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
   -F 'database=@/my-folder/database.gz' \
   -F 'volume=@/my-folder/volume.tgz' \

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service/restoring-data-from-a-backup.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service/restoring-data-from-a-backup.md
@@ -7,14 +7,14 @@ You can also use custom SQL scripts to perform additional updates to a database 
 See [Backup Service](./backup-service-overview.md) and [Downloading and Uploading Backups](./downloading-and-uploading-backups.md) for more information about the Backups page.
 
 ```important::
-   The Backups page is only available for production (``prd``) environments. Only users with the Admin role for the prod environment can manually restore environments via the DXP Cloud console.
+   Only users with the Admin role for the chosen environment can manually restore environments via the DXP Cloud console.
 ```
 
 ## Restoring an Environment from the Backups Page
 
 Follow these steps to restore an environment from a backup:
 
-1. Navigate to your project's `prd` environment.
+1. Navigate to your project's chosen environment.
 
 1. Click on *Backups* in the environment menu.
 
@@ -29,7 +29,7 @@ Follow these steps to restore an environment from a backup:
    ![Figure 2: Select the environment you want to restore.](./restoring-data-from-a-backup/images/02.png)
 
    ```note::
-      Production environment administrators can only restore environments to which they have access.
+      Administrators can only restore environments to which they have access.
    ```
 
 1. Click all *checkboxes* that appear below. You must check these boxes to enable the button to initiate the restore.

--- a/docs/dxp-cloud/latest/en/platform-services/database-service/changing-your-database-password.md
+++ b/docs/dxp-cloud/latest/en/platform-services/database-service/changing-your-database-password.md
@@ -10,9 +10,9 @@ Changing the MySQL password for your [`database` service](./database-service.md)
 
 If you are changing the password for a production environment, then you must ensure you have an up-to-date backup so you can restore it after the update.
 
-To create a backup, navigate to your production (`prd`) environment and click _Backups_ from the menu on the left:
+To create a backup for any environment, click _Backups_ from the menu on the left:
 
-![Navigate to your production environment's Backups page.](./changing-your-database-password/images/01.png)
+![Navigate to your chosen environment's Backups page.](./changing-your-database-password/images/01.png)
 
 Then, click _Backup Now_ on the _Backups_ page:
 
@@ -86,7 +86,7 @@ When you are ready, follow these steps to change your database password:
 
     The database service starts up using the updated password. The `liferay` and `backup` services restart to reconnect to the database service with the correct password, as well.
 
-1. If you [prepared a backup](#creating-a-backup), then navigate to your **production** environment's _Backups_ page, and [restore the backup](../backup-service/restoring-data-from-a-backup.md).
+1. If you [prepared a backup](#creating-a-backup), then navigate to your chosen environment's _Backups_ page, and [restore the backup](../backup-service/restoring-data-from-a-backup.md).
 
 Your `database` service is now updated with a new password, and your other services are synchronized to connect to it properly.
 

--- a/docs/dxp-cloud/latest/en/reference/dxp-cloud-infrastructure.md
+++ b/docs/dxp-cloud/latest/en/reference/dxp-cloud-infrastructure.md
@@ -64,7 +64,7 @@ By default, the Web Server, Liferay DXP, and Backup services store volumes using
 
 ## Backups
 
-DXP Cloud stores a copy of the Database service and volumes from Liferay DXP within its private network. Backups are generated specifically for production environents, but customers can choose to restore a backup from production to any environment. By default, backups are accessible to public web traffic through HTTP(S) connections.
+DXP Cloud stores a copy of the Database service and volumes from Liferay DXP within its private network. Customers can manually create a backup from any environment, and restore that backup to any other environment. By default, backups are accessible to public web traffic through HTTP(S) connections.
 
 Backups are offered as one of DXP Cloud's main services, and its rules of operation (such as backup frequency and retention) can be freely configured. See the [Backup Service Overview](../platform-services/backup-service/backup-service-overview.md) for more information.
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/migrating-from-an-on-premises-dxp-installation.md
@@ -53,19 +53,19 @@ Run this command to invoke the API and upload the zipped files:
 
 ```bash
 curl -X POST \
-  https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/upload \
+  https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/upload \
   -H 'Content-Type: multipart/form-data' \
   -F 'database=@/my-folder/database.tgz' \
   -F 'volume=@/my-folder/volume.tgz' \
   -u user@domain.com:password
 ```
 
-Substitute `<PROJECT-NAME>` with the appropriate name for your DXP Cloud project. Substitute `/my-folder` with the correct path to the zipped files.
+Substitute `<PROJECT-NAME>` with the appropriate name for your DXP Cloud project. Substitute `<ENV>` with the abbreviation corresponding to your chosen environment (such as `dev` or `prd`). Substitute `/my-folder` with the correct path to the zipped files.
 
 Once these are uploaded, the backup service will initialize a DXP Cloud backup.
 
 ```note::
-   The backup will appear on the `Backups` page in your ``prd`` environment, but it will not apply to any of your environments until you choose to restore it.
+   The backup will appear on the `Backups` page in your chosen environment, but it will not apply to any of your environments until you choose to restore it.
 ```
 
 ## Copy Liferay DXP Configurations
@@ -103,7 +103,7 @@ Now that the backup has been uploaded and your service configurations are applie
 
 1. Log into the DXP Cloud console, if you are not already logged in.
 
-1. Navigate to your production environment, then click _Backups_ from the side menu.
+1. Navigate to the environment you [uploaded your backup to](#invoke-backup-service-api), then click _Backups_ from the side menu.
 
 1. Choose the newly uploaded backup on the list, and then click _Restore to_ from the Actions menu for that backup.
 

--- a/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/upgrading-your-liferay-dxp-instance.md
+++ b/docs/dxp-cloud/latest/en/using-the-liferay-dxp-service/upgrading-your-liferay-dxp-instance.md
@@ -206,8 +206,10 @@ Upload the database and document library archives to the `backup` service by cal
 1. Run the following command to call the upload API after modifying it for your project:
 
     ```bash
-    curl -X POST https://backup-<PROJECT-NAME>-prd.lfr.cloud/backup/upload -H 'Content-Type: multipart/form-data' -H 'Authorization: Bearer <USER-TOKEN>' -F 'database=@/path/to/folder/database.tgz' -F 'volume=@/path/to/folder/volume.tgz'
+    curl -X POST https://backup-<PROJECT-NAME>-<ENV>.lfr.cloud/backup/upload -H 'Content-Type: multipart/form-data' -H 'Authorization: Bearer <USER-TOKEN>' -F 'database=@/path/to/folder/database.tgz' -F 'volume=@/path/to/folder/volume.tgz'
     ```
+
+    Replace `<PROJECT-NAME>` with the name of your project, and `/path/to/folder/` with the path your `.tgz` archives are located. Replace `<ENV>` with the abbreviation for the environment you want to upload the upgraded backup to (such as `dev`).
 
 When the call is complete, a new backup appears from your upload, on the _Backups_ page in the DXP Cloud console.
 
@@ -217,7 +219,7 @@ Follow these steps to restore a backup to your chosen environment:
 
 1. Log into the DXP Cloud console, if you are not already logged in.
 
-1. Navigate to your production environment, then click _Backups_ from the side menu.
+1. Navigate to the environment [you uploaded your backup to](#call-the-upload-api), then click _Backups_ from the side menu.
 
 1. Choose a backup from the list, and then click _Restore to_ from the Actions menu for that backup.
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9535

Backups can now be created in any environment, not just production environments. This is a set of sweeping changes to verbiage that should hopefully address this altogether.