### PR TITLE
LRDOCS-9517 Liveness Readiness Probes (DXPCloud) Wordsmithed

### DIFF
--- a/docs/dxp-cloud/latest/en/troubleshooting/self-healing.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/self-healing.md
@@ -19,19 +19,19 @@ Each probe can be configured with the following options:
 | `successThreshold` | Minimum consecutive successes for the probe to be considered successful following a failure. The default and minimum is `1`. Must be `1` for liveness. |
 | `failureThreshold` | The number of times DXP Cloud repeats a failed probe before giving up. For a liveness probe, giving up means the service will restart. For a readiness probe, giving up means the probe will be marked as Failed. The default is `3`; the minimum is `1`. |
 
-When a probe detects a failure (i.e., it does not return the success message in a status check), the probe automatically takes action to address it (restarting the service or redirecting traffic away from the instance). The probes themselves *do not cause* outages, but they instead attempt to automatically detect and respond to them.
+When a probe detects a failure (i.e., it does not return the success message in a status check), the probe automatically takes action to address it (restarting the service or redirecting traffic away from the instance). The probes themselves *do not cause* outages, but they instead attempt to detect and respond to them automatically.
 
-The liveness and readiness probes are deployed to all services regardless of the environment. Typically, customers do not have to make any changes to the probes unless they would like to adjust their values based on their needs. For example, a system administrator may increase the `initialDelaySeconds` value to account for a longer startup process.
+The liveness and readiness probes are deployed to all services regardless of the environment. Typically, customers do not have to make changes to the probes unless they want to adjust their values based on their needs. For example, a system administrator may increase the `initialDelaySeconds` value to account for a longer startup process.
 
 To change the default values, modify the `lcp.json` file. See the [Configuration via LCP.json](../reference/configuration-via-lcp-json.md) article.
 
 ### Liveness Probe
 
-The liveness probe uses a URL Request (path/port) to validate that a service is running. This probe repeatedly pings a configurable path (by default, `/c/portal/layout`). Often, the liveness probe is a lightweight HTTP server inside the application to respond to the liveness probe.
+The liveness probe uses a URL Request (path/port) to validate that a service is running. This probe repeatedly pings a configurable path (by default, `/c/portal/layout`). Often, the liveness probe is a lightweight HTTP server inside the application. 
 
-If the probe gets an HTTP response in the 200 or 300 range, it marks the application as healthy. It fails if the instance is no longer live (for example, due to a crash). If the probe pings the path a number of times (configurable via the probe's `failureThreshold` field in `LCP.json`) and cannot get a valid response, then the service automatically restarts.
+If the probe gets an HTTP response in the 200 or 300 range, it marks the application as healthy. It fails if the instance is no longer live (for example, due to a crash). If the probe pings the path a number of times (configurable via the probe's `failureThreshold` field in `LCP.json`) and cannot get a valid response, the service automatically restarts.
 
-Each service's `LCP.json` file contains the following:
+Each service's `LCP.json` file contains the following configuration:
 
 ```json
 {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-9517

@Alec-Shay

- LRDOCS-9517 Add information clarifying actions liveness/readiness probes take when detcting failures (only information on Slab not already represented)
- LRDOCS-9517 Wordsmithing.
