### PR TITLE
workflow 7.x | fix links to workflow xml | LRDOCS-9574

### DIFF
--- a/docs/dxp/latest/en/process-automation/workflow/designing-and-managing-workflows/workflow-designer/creating-workflow-tasks.md
+++ b/docs/dxp/latest/en/process-automation/workflow/designing-and-managing-workflows/workflow-designer/creating-workflow-tasks.md
@@ -2,7 +2,7 @@
 
 > Subscribers
 
-The default [Single Approver Definition](./workflow-designer-overview/resources/single-approver-definition.xml) offers a simple introduction to workflow tasks. It has only two task nodes: Review and Update. The workflow enters the Review node when a content creator submits an asset for review. In review, the asset can be accepted or rejected. If it's rejected, the process moves to the Update task. The submitter can then modify the asset and resubmit it for review.
+The default [Single Approver Definition](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml) offers a simple introduction to workflow tasks. It has only two task nodes: Review and Update. The workflow enters the Review node when a content creator submits an asset for review. In review, the asset can be accepted or rejected. If it's rejected, the process moves to the Update task. The submitter can then modify the asset and resubmit it for review.
 
 ![The single approver definition has two task nodes.](./creating-workflow-tasks/images/01.png)
 

--- a/docs/dxp/latest/en/process-automation/workflow/designing-and-managing-workflows/workflow-designer/workflow-designer-overview.md
+++ b/docs/dxp/latest/en/process-automation/workflow/designing-and-managing-workflows/workflow-designer/workflow-designer-overview.md
@@ -20,12 +20,12 @@ The workflow designer supports all [workflow node](./workflow-nodes.md) types:
 
 In addition to the functionality provided by the drag and drop interface, you have the full power of Groovy (a Java-based scripting language) to perform [programmatic actions](./../../developer-guide/using-the-script-engine-in-workflow.md) on assets being moved through your workflows.
 
-By default, only one workflow definition is installed: the Single Approver Workflow definition. You can download additional definitions here:
+By default, only one workflow definition is installed: the Single Approver Workflow definition. You can see additional examples in the Liferay source code:
 
-* [Category-Specific Definition](./workflow-designer-overview/resources/category-specific-definition.xml)
-* [Legal Marketing Definition](./workflow-designer-overview/resources/legal-marketing-definition.xml)
-* [Single Approver Definition with Scripted Assignment](./workflow-designer-overview/resources/single-approver-definition-scripted-assignment.xml)
-* [Single Approver Definition](./workflow-designer-overview/resources/single-approver-definition.xml)
+* [Category-Specific Definition](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/category-specific-definition.xml)
+* [Legal Marketing Definition](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/legal-marketing-definition.xml)
+* [Single Approver Definition with Scripted Assignment](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition-scripted-assignment.xml)
+* [Single Approver Definition](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml)
 
 ## Building Workflows
 

--- a/docs/dxp/latest/en/process-automation/workflow/developer-guide/crafting-xml-workflow-definitions.md
+++ b/docs/dxp/latest/en/process-automation/workflow/developer-guide/crafting-xml-workflow-definitions.md
@@ -18,10 +18,10 @@ Once you publish your workflow, it becomes available to be applied everywhere wo
 
 Only one workflow definition is installed by default: Single Approver. Several more are embedded in the Liferay source code. These definitions provide good examples of all the features described here.
 
-* [Category Specific](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/category-specific-definition.xml)
-* [Legal Marketing](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/legal-marketing-definition.xml)
-* [Single Approver](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/single-approver-definition.xml)
-* [Single Approver Scripted Assignment](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/single-approver-definition-scripted-assignment.xml)
+* [Category Specific](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/category-specific-definition.xml)
+* [Legal Marketing](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/legal-marketing-definition.xml)
+* [Single Approver](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml)
+* [Single Approver Scripted Assignment](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition-scripted-assignment.xml)
 Below you'll learn the basics by using the simplest workflow, Single Approver. The Single Approver workflow contains two required States: Start and End, which are named _created_ and _approved_. It also contains two Tasks: _review_ and _update_. These Tasks define _Actions_, such as _approve_, _reject_, and _resubmit_. 
 
 When breaking down your workflow into its components, then, think about your States, Tasks, and Actions. Once you have them defined, you're ready to get to work. Now you're ready to put it all together by seeing how the Single Approver workflow works. 
@@ -53,7 +53,7 @@ Give the definition a name, description, and version:
 
 ## Start and End Nodes
 
-Each workflow definition begins and ends with a _State Node_. Create a _Start_ node like this one from the [Single Approver](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/single-approver-definition.xml):
+Each workflow definition begins and ends with a _State Node_. Create a _Start_ node like this one from the [Single Approver](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml):
 
 ```xml
 <state>

--- a/docs/dxp/latest/en/process-automation/workflow/developer-guide/workflow-task-node-reference.md
+++ b/docs/dxp/latest/en/process-automation/workflow/developer-guide/workflow-task-node-reference.md
@@ -67,7 +67,7 @@ Workflow tasks are completed by a User. Assignments make sure the right users ca
 * Resource actions
 * Specific Users
 
-Additionally, you can write a script to define the assignment. For an example, see the [single-approver-definition-scripted-assignment.xml](../designing-and-managing-workflows/workflow-designer/workflow-designer-overview/resources/single-approver-definition-scripted-assignment.xml).
+Additionally, you can write a script to define the assignment. For an example, see the [single-approver-definition-scripted-assignment.xml](https://github.com/liferay/liferay-portal/blob/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition-scripted-assignment.xml).
 
 ```xml
 <assignments>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-9574
cc @sez11a
The example workflow definitions were added to the root of a `resources` folder, which worked after I  did the intial support for including any files at the root of the resources folder, but no longer does since we're now just looking for `mp4` files in the images folders. I've replaced the links with links to GitHub.