### PR TITLE
liferay-learn | rename.py script minor fix

### DIFF
--- a/bin/rename.py
+++ b/bin/rename.py
@@ -139,9 +139,13 @@ if __name__ == "__main__":
     print(Fore.YELLOW + "------------")
     for renamefile in renamelist[0]:
 
-        newfilename = re.sub(oldName, newName, renamefile, 1, 0)
+        oldpathend = os.path.split(os.path.relpath(renamefile))[1]
 
-        os.rename(renamefile, newfilename)
+        newpathend = re.sub(oldName, newName, oldpathend)
+
+        newfilename = os.path.join(os.path.split(os.path.relpath(renamefile))[0],newpathend)
+
+        os.rename(os.path.relpath(renamefile), newfilename)
 
         print(Fore.BLUE + renamefile + "\n" + Fore.WHITE + " was renamed to " +
               "\n" + Fore. BLUE + newfilename)


### PR DESCRIPTION
I noticed that it didn't handle the case where the old string appeared twice in a path, like with search-results/search-results.md
This takes care of it, though the user still has to know to exclude the parent article manually (a cli selection mechanism for choosing which paths to edit is already part of the script)