### PR TITLE
[DXP Cloud] Fixing links to renamed Reading DXP Cloud Service Logs article

### DIFF
--- a/docs/dxp-cloud/latest/en/getting-started/introduction-to-dxp-cloud.md
+++ b/docs/dxp-cloud/latest/en/getting-started/introduction-to-dxp-cloud.md
@@ -56,7 +56,7 @@ These robust systems enable the creation of fault tolerant processes to meet org
 
 ## Application Development Tools
 
-Keep track of application deployments and performance with real-time build and [deployment logs](../troubleshooting/log-management.md). Teams can analyze stack traces and troubleshoot bugs by [accessing the shell](../troubleshooting/shell-access.md) via the web console or terminal, and/or by downloading the logs.
+Keep track of application deployments and performance with real-time build and [deployment logs](../troubleshooting/reading-dxp-cloud-service-logs.md). Teams can analyze stack traces and troubleshoot bugs by [accessing the shell](../troubleshooting/shell-access.md) via the web console or terminal, and/or by downloading the logs.
 
 ![Figure 8: Real-time build and deployment logs help you solve problems with your applications.](./introduction-to-dxp-cloud/images/06.png)
 

--- a/docs/dxp-cloud/latest/en/manage-and-optimize/team-activities.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/team-activities.md
@@ -44,4 +44,4 @@ This page lists all activities that have occurred on the DXP Cloud instance.
 
 * [Environment Teams and Roles](./environment-teams-and-roles.md)
 * [Overview of the DXP Cloud Deployment Workflow](../build-and-deploy/overview-of-the-dxp-cloud-deployment-workflow.md)
-* [Log Management](../troubleshooting/log-management.md)
+* [Log Management](../troubleshooting/reading-dxp-cloud-service-logs.md)

--- a/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
+++ b/docs/dxp-cloud/latest/en/platform-services/backup-service/backup-service-overview.md
@@ -54,7 +54,7 @@ Once started, the backup service icon will indicate a backup is in progress, and
 
 Clicking *View logs* redirects you to the Logs page, where you can view the backup stages in real-time. You can also view backup logs in the *Logs* tab of the backup service's page.
 
-See [Log Management](../../troubleshooting/log-management.md) for more information about viewing service logs.
+See [Log Management](../../troubleshooting/reading-dxp-cloud-service-logs.md) for more information about viewing service logs.
 
 ## Configuring the Backup Service
 

--- a/docs/dxp-cloud/latest/en/troubleshooting/support-access.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/support-access.md
@@ -40,4 +40,4 @@ DXP Cloud also sends an email to all team members when the Support Access settin
 
 * [Troubleshooting Tools and Resources](./troubleshooting-tools-and-resources.md)
 * [Help Center](https://help.liferay.com/hc/en-us)
-* [Log Management](./log-management.md)
+* [Log Management](./reading-dxp-cloud-service-logs.md)

--- a/docs/dxp-cloud/latest/en/troubleshooting/troubleshooting-tools-and-resources.md
+++ b/docs/dxp-cloud/latest/en/troubleshooting/troubleshooting-tools-and-resources.md
@@ -63,7 +63,7 @@ Application, status, and build logs are provided for each DXP Cloud Service:
 
 ![Figure 4: View logs via the Logs page in the DXP Cloud console](./troubleshooting-tools-and-resources/images/04.png)
 
-See [Log Management](./log-management.md) for more information.
+See [Log Management](./reading-dxp-cloud-service-logs.md) for more information.
 
 ## Shell Access
 


### PR DESCRIPTION
This fixes links broken by renaming the old "Log Management" article.

Also, I noticed that it looks like the "log" language for code blocks (some of which were also added into that article) is not actually supported and that causes errors too (though we use it in other areas too... so they must all be causing errors). However, I originally added those because without any language indicator, it would add really distracting highlighting that doesn't make much sense... so I think it looks better... even though the language is broken... so I'm not sure what to suggest to address the errors on that front.