### PR TITLE
LRDOCS-9676 removes GCS documentation pending feature release

### DIFF
--- a/docs/dxp/latest/en/system-administration/file-storage/other-file-store-types/google-cloud-storage.md
+++ b/docs/dxp/latest/en/system-administration/file-storage/other-file-store-types/google-cloud-storage.md
@@ -1,5 +1,8 @@
 # Google Cloud Storage
 
+Coming soon!
+
+<!--
 > Available for 7.4+ and 7.3 FP2+
 
 Liferay DXP provides integration with Google's Cloud Storage (GCS) service. With GCS integration, you can seamlessly store and access your Liferay instance files in the cloud.
@@ -69,4 +72,4 @@ Follow these steps to use GCS as the default Store for the Liferay instance:
 ## Additional Information
 
 * [Portal Properties](../../../installation-and-upgrades/reference/portal-properties.md)
-* [Configuring File Storage](../configuring-file-storage.md)
+* [Configuring File Storage](../configuring-file-storage.md) -->

--- a/docs/dxp/latest/en/system-administration/file-storage/other_file_store_types.rst
+++ b/docs/dxp/latest/en/system-administration/file-storage/other_file_store_types.rst
@@ -8,10 +8,8 @@ Other File Store Types
    other-file-store-types/amazon-s3-store.md
    other-file-store-types/dbstore.md
    other-file-store-types/ibm-cloud-object-storage.md
-   other-file-store-types/google-cloud-storage.md
 
 -  :doc:`/system-administration/file-storage/other-file-store-types/simple-file-system-store`
 -  :doc:`/system-administration/file-storage/other-file-store-types/amazon-s3-store`
 -  :doc:`/system-administration/file-storage/other-file-store-types/dbstore`
 -  :doc:`/system-administration/file-storage/other-file-store-types/ibm-cloud-object-storage`
--  :doc:`/system-administration/file-storage/other-file-store-types/google-cloud-storage`

--- a/docs/dxp/latest/en/system-administration/file_storage.rst
+++ b/docs/dxp/latest/en/system-administration/file_storage.rst
@@ -23,4 +23,3 @@ Other File Store Types
 -  :doc:`/system-administration/file-storage/other-file-store-types/simple-file-system-store`
 -  :doc:`/system-administration/file-storage/other-file-store-types/amazon-s3-store`
 -  :doc:`/system-administration/file-storage/other-file-store-types/dbstore`
--  :doc:`/system-administration/file-storage/other-file-store-types/google-cloud-storage`


### PR DESCRIPTION
This PR comments out the Google Cloud Storage article and removes it from `file_storage.rst` and `other_file_store_types.rst`, per [LRDOCS-9676](https://issues.liferay.com/browse/LRDOCS-9676).