### PR TITLE
[DXP Cloud] LRDOCS-10159 Add example configuration files reference article

### DIFF
--- a/docs/dxp-cloud/latest/en/migrating-to-dxp-cloud/migrating-search-configurations.md
+++ b/docs/dxp-cloud/latest/en/migrating-to-dxp-cloud/migrating-search-configurations.md
@@ -26,7 +26,7 @@ In the project repository you [cloned previously](./matching-dxp-versions.md#clo
 All custom shell scripts in the appropriate folder run each time the `search` service is redeployed.
 
 ```{tip}
-As an example Elasticsearch configuration, download this [sample Elasticsearch .yml file](https://drive.google.com/file/d/1rhfH2E0tvLgyoIjd6x2191yrNW2Y7ekD/view).
+To see what an Elasticsearch configuration file looks like, see the example configuration [here](../reference/example-configuration-files.md#search-service-configuration-elasticsearch-yml).
 ```
 
 ## Add Extra Search Plugins

--- a/docs/dxp-cloud/latest/en/migrating-to-dxp-cloud/migrating-web-server-configurations.md
+++ b/docs/dxp-cloud/latest/en/migrating-to-dxp-cloud/migrating-web-server-configurations.md
@@ -31,7 +31,7 @@ Any files put into the `webserver/configs/common/` folder applies to all environ
 See [Web Server Service Configurations](../platform-services/web-server-service.md#configurations) for more information.
 
 ```{tip}
-As an example Nginx configuration, download this [sample Nginx .conf file](https://drive.google.com/file/d/10nt2ys4GWh-M40NOljrQsWlbOIjuYnf8/view).
+To see what an Nginx configuration file looks like, see the example configuration [here](../reference/example-configuration-files.md#web-server-service-configuration-nginx-conf).
 ```
 
 ## Organize Web Server Customizations

--- a/docs/dxp-cloud/latest/en/reference.md
+++ b/docs/dxp-cloud/latest/en/reference.md
@@ -12,6 +12,7 @@ reference/upgrading-to-a-high-availability-subscription.md
 reference/command-line-tool.md
 reference/defining-environment-variables.md
 reference/platform-limitations.md
+reference/example-configuration-files.md
 ```
 
 - [DXP Cloud Infrastructure](./reference/dxp-cloud-infrastructure.md)
@@ -23,3 +24,4 @@ reference/platform-limitations.md
 - [Command-Line Tool](./reference/command-line-tool.md)
 - [Defining Environment Variables](./reference/defining-environment-variables.md)
 - [Platform Limitations](./reference/platform-limitations.md)
+- [Example Configuration Files](./reference/example-configuration-files.md)

--- a/docs/dxp-cloud/latest/en/reference/example-configuration-files.md
+++ b/docs/dxp-cloud/latest/en/reference/example-configuration-files.md
@@ -1,0 +1,23 @@
+# Example Configuration Files
+
+Different services in DXP Cloud (such as the [search](../platform-services/search-service.md) and [web server](../platform-services/web-server-service.md) services) use configuration files to perform what you might be used to handling differently in an on-premises environment. Here are some example resources you can use as a starting point to see what these files look like when you are getting started with DXP Cloud.
+
+## Web Server Service Configuration (nginx.conf)
+
+The web server service uses an [Nginx](link) server to manage web traffic. Here is an example `nginx.conf` file:
+
+```{literalinclude} ./example-configuration-files/resources/nginx.conf
+:lines: 1-81
+```
+
+The `nginx.conf` file belongs in the `webserver/configs/{ENV}/conf.d/` directory in your project repository.
+
+## Search Service Configuration (elasticsearch.yml)
+
+The search service uses an [Elasticsearch](https://www.elastic.co/guide/index.html) server to handle search queries in your Liferay instance. Here is an example `elasticsearch.yml` file:
+
+```{literalinclude} ./example-configuration-files/resources/elasticsearch.yml
+:lines: 1-27
+```
+
+The `elasticsearch.yml` file belongs in the `search/configs/{ENV}/config/` directory in your project repository.

--- a/docs/dxp-cloud/latest/en/reference/example-configuration-files/resources/elasticsearch.yml
+++ b/docs/dxp-cloud/latest/en/reference/example-configuration-files/resources/elasticsearch.yml
@@ -1,0 +1,27 @@
+cluster:
+  name: ${CLUSTER_NAME}
+
+node:
+  master: ${NODE_MASTER}
+  name: ${HOSTNAME}
+  data: ${NODE_DATA}
+  ingest: ${NODE_INGEST}
+
+network.host: ${NETWORK_HOST}
+
+path:
+  data: /data/data
+  logs: /data/log
+
+bootstrap:
+  memory_lock: ${MEMORY_LOCK}
+
+discovery:
+  zen:
+    minimum_master_nodes: ${LCP_MINIMUM_MASTER_NODES}
+    ping:
+      unicast:
+        hosts: ${PING_UNICAST_HOST}
+
+xpack.security.enabled: ${ENABLE_XPACK_SECURITY}
+xpack.monitoring.enabled: ${ENABLE_XPACK_MONITORING}

--- a/docs/dxp-cloud/latest/en/reference/example-configuration-files/resources/nginx.conf
+++ b/docs/dxp-cloud/latest/en/reference/example-configuration-files/resources/nginx.conf
@@ -1,0 +1,81 @@
+user  nginx;
+worker_processes  2;
+
+load_module modules/ngx_http_headers_more_filter_module.so;
+load_module modules/ngx_http_auth_spnego_module.so;
+
+error_log  /var/log/nginx/error.log ${ERROR_LOG_LEVEL};
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  10000;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '${LCP_WEBSERVER_LOG_FORMAT}';
+
+    access_log  /var/log/nginx/access.log main;
+
+    more_clear_headers Server;
+    server_tokens   off;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types  text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+    server_names_hash_bucket_size 64;
+    client_max_body_size 0;
+
+    upstream upstream_server {
+        keepalive 7000;
+        server ${PROXY_ADDRESS};
+    }
+
+    server {
+        listen 80 default_server;
+        large_client_header_buffers 4 32k;
+
+        if ($http_x_forwarded_proto = "http") {
+            return 301 https://$host$request_uri;
+        }
+
+        fastcgi_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        uwsgi_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        uwsgi_send_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        proxy_connect_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        proxy_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        proxy_send_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+        proxy_max_temp_file_size ${LCP_WEBSERVER_PROXY_MAX_TEMP_FILE_SIZE};
+
+        include /etc/nginx/conf.d/*.conf;
+
+        location /nginx_status {
+            access_log ${NGINX_STATUS_ACCESS_LOG};
+            stub_status on;
+
+            fastcgi_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+            uwsgi_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+            uwsgi_send_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+            proxy_connect_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+            proxy_read_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+            proxy_send_timeout ${LCP_WEBSERVER_GLOBAL_TIMEOUT};
+
+            allow 10.0.0.0/8;
+            deny all;
+        }
+    }
+
+    set_real_ip_from 10.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+}


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-10159

This replaces the reference to external downloads for example config files with a reference to a new article that shows the configuration instead (more in line with our convention).