### PR TITLE
Escape $ to display content correctly

### DIFF
--- a/docs/dxp/latest/en/building-applications/tooling/other-tools/liferay-npm-bundler/how-portal-publishes-npm-packages.md
+++ b/docs/dxp/latest/en/building-applications/tooling/other-tools/liferay-npm-bundler/how-portal-publishes-npm-packages.md
@@ -64,11 +64,11 @@ Using the example above, for each group of canonical URLs referring to the same 
 
 * [http://localhost/o/js/resolved-module/my-bundle-package@1.0.0/lib/index.js](http://localhost/o/js/resolved-module/my-bundle-package@1.0.0/lib/index.js)
 
-* [http://localhost/o/js/resolved-module/my-bundle-package$isobject@2.1.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package$isobject@2.1.0/index.js)
+* [http://localhost/o/js/resolved-module/my-bundle-package\$isobject@2.1.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package\$isobject@2.1.0/index.js)
 
-* [http://localhost/o/js/resolved-module/my-bundle-package$isarray@1.0.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package$isarray@1.0.0/index.js)
+* [http://localhost/o/js/resolved-module/my-bundle-package\$isarray@1.0.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package\$isarray@1.0.0/index.js)
 
-* [http://localhost/o/js/resolved-module/my-bundle-package$isarray@2.0.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package$isarray@2.0.0/index.js)
+* [http://localhost/o/js/resolved-module/my-bundle-package\$isarray@2.0.0/index.js](http://localhost/o/js/resolved-module/my-bundle-package\$isarray@2.0.0/index.js)
 
 ```{note}
 The OSGi bundle ID (598 in the example) is removed and module is replaced by `resolved-module`.


### PR DESCRIPTION
Currently, the symbol `$` isn't being properly escaped and it's affecting the content to be displayed, as can be seen below:

![image](https://user-images.githubusercontent.com/6729287/154700013-29f28dff-d5b9-4425-864a-7c4c8eccb5e1.png)

Fix sponsored by @rbohl :smile: :clap: 